### PR TITLE
fix: add default embedding model to support none openai model

### DIFF
--- a/lpm_kernel/L2/data_pipeline/graphrag_indexing/settings.yaml
+++ b/lpm_kernel/L2/data_pipeline/graphrag_indexing/settings.yaml
@@ -38,6 +38,7 @@ models:
     retry_strategy: native
     tokens_per_minute: 0
     type: openai_chat
+    encoding_model: cl100k_base
   default_embedding_model:
     api_base: https://api.openai.com/v1
     api_key: sk-xxxxxx


### PR DESCRIPTION
Due to validation by graphrag, many models fail to pass; thus, a default encoding model has been added. Although this may result in an imprecise token count, the resulting error is acceptable.