### PR TITLE
security!

### DIFF
--- a/lpm_kernel/L2/utils.py
+++ b/lpm_kernel/L2/utils.py
@@ -357,7 +357,11 @@ def save_hf_model(model_name="Qwen2.5-0.5B-Instruct", log_file_path=None) -> str
     # Setup logging
     logger = setup_logger(log_file_path)
     
-    save_path = os.path.join(os.getcwd(), "resources/L2/base_models", model_name)
+    base_dir = os.path.join(os.getcwd(), "resources/L2/base_models")
+    normalized_model_name = os.path.normpath(model_name)
+    if ".." in normalized_model_name or normalized_model_name.startswith("/"):
+        raise ValueError("Invalid model name")
+    save_path = os.path.join(base_dir, normalized_model_name)
     os.makedirs(save_path, exist_ok=True)
 
     from huggingface_hub import list_repo_files, configure_http_backend

--- a/lpm_kernel/api/domains/trainprocess/routes.py
+++ b/lpm_kernel/api/domains/trainprocess/routes.py
@@ -2,7 +2,7 @@ import json
 import logging
 import time
 from pathlib import Path
-
+from werkzeug.utils import secure_filename
 from flask import Blueprint, jsonify, Response, request
 
 from lpm_kernel.file_data.trainprocess_service import TrainProcessService
@@ -170,9 +170,10 @@ def stream_logs():
 @trainprocess_bp.route("/progress/<model_name>", methods=["GET"])
 def get_progress(model_name):
     """Get current progress (non-real-time)"""
-    progress_name = f'trainprocess_progress_{model_name}.json'  # Build filename based on the provided model_name
+    sanitized_model_name = secure_filename(model_name)  # Sanitize model_name
+    progress_name = f'trainprocess_progress_{sanitized_model_name}.json'  # Build filename based on the sanitized model_name
     try:
-        train_service = TrainProcessService(progress_file=progress_name, model_name=model_name)  # Pass in specific progress file
+        train_service = TrainProcessService(progress_file=progress_name, model_name=sanitized_model_name)  # Pass in specific progress file
         progress = train_service.progress.progress
 
         return jsonify(

--- a/lpm_kernel/file_data/trainprocess_service.py
+++ b/lpm_kernel/file_data/trainprocess_service.py
@@ -95,7 +95,9 @@ class Progress:
         progress_dir = os.path.join(os.getcwd(), "data/progress")
         if not os.path.exists(progress_dir):
             os.makedirs(progress_dir)
-        self.progress_file = os.path.join(progress_dir, progress_file)
+        self.progress_file = os.path.normpath(os.path.join(progress_dir, progress_file))
+        if not self.progress_file.startswith(progress_dir):
+            raise ValueError("Invalid progress file path")
         self.progress = TrainProgress()
         self.progress_callback = progress_callback
         self.logger = logging.getLogger(__name__)


### PR DESCRIPTION
I've analyzed the code for potential path traversal vulnerabilities. Here's my assessment:
Path Traversal Vulnerability Report
The code contains a potential path traversal vulnerability in the save_hf_model function when handling file downloads from Hugging Face repositories. This vulnerability could allow an attacker to write files outside the intended directory.
Vulnerability Details
In the download_file_with_progress function, there's a critical security issue:
pythonCopy# Target file path
local_file_path = os.path.join(save_path, filename)
os.makedirs(os.path.dirname(local_file_path), exist_ok=True)
This code doesn't sanitize or validate the filename parameter, which comes from the list of files in the Hugging Face repository. If an attacker could control repository content, they could include malicious filenames with path traversal sequences like ../../../etc/passwd to potentially write files outside the intended directory.
Impact
An attacker who can control the content of a Hugging Face repository could:

Write files to arbitrary locations on the filesystem where the program has write permissions
Overwrite existing files
Potentially achieve code execution by writing to sensitive locations

Evidence

The code uses os.path.join() without validating that the resulting path stays within the intended directory
os.makedirs() with exist_ok=True will create any directory structure specified, including those outside the intended path
There is no path normalization or validation before writing files

Recommended Fix
Implement proper path validation to ensure the final path remains within the intended directory:
pythonCopydef is_safe_path(base_dir, path):
    # Normalize both paths
    base_dir = os.path.normpath(os.path.abspath(base_dir))
    requested_path = os.path.normpath(os.path.abspath(os.path.join(base_dir, path)))
    # Check if the normalized path starts with the base directory
    return requested_path.startswith(base_dir)

# Then in the download function:
if not is_safe_path(save_path, filename):
    logger.error(f"Attempted path traversal detected: {filename}")
    return filename, False
Additional Security Recommendations

Consider using a dedicated library for secure file operations, such as Python's pathlib with proper validation
Add a scanning step to identify and reject suspicious filenames before downloading
Implement a whitelist of allowed file extensions and patterns
Run the process with minimal necessary permissions

This vulnerability should be addressed promptly as it could allow for arbitrary file writes on systems using this code.  
 
-lpm_kernel/L2/utils.py
