### PR TITLE
feat(logging): separate training log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ run/*
 #config
 .backend.pid
 .frontend.pid
+logs/train/

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ resources/L2/data/*
 resources/model/output/gguf/*
 resources/L2/base_models/*
 logs/*.log
+logs/train/*.log
 
 # Runtime files
 run/*

--- a/lpm_kernel/L1/shade_generator.py
+++ b/lpm_kernel/L1/shade_generator.py
@@ -1,6 +1,5 @@
 from typing import Dict, List, Any, Optional
 import json
-import logging
 import re
 import traceback
 
@@ -26,6 +25,11 @@ from lpm_kernel.L1.prompt import (
 from lpm_kernel.api.services.user_llm_config_service import UserLLMConfigService
 from lpm_kernel.configs.config import Config
 
+from lpm_kernel.api.common.script_executor import ScriptExecutor
+
+from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
+setup_logging()
+logger = get_train_process_logger()
 
 class ShadeGenerator:
     def __init__(self):
@@ -125,12 +129,12 @@ Domain Timelines:
         """
         matches = re.findall(pattern, content, re.DOTALL)
         if not matches:
-            logging.error(f"No Json Found: {content}")
+            logger.error(f"No Json Found: {content}")
             return default_res
         try:
             json_res = json.loads(matches[0])
         except Exception as e:
-            logging.error(f"Json Parse Error: {traceback.format_exc()}-{content}")
+            logger.error(f"Json Parse Error: {traceback.format_exc()}-{content}")
             return default_res
         return json_res
 
@@ -148,10 +152,10 @@ Domain Timelines:
         shade_raw_info = self.__parse_json_response(content, shade_generate_pattern)
 
         if not shade_raw_info:
-            logging.error(f"Failed to parse the shade generate result: {content}")
+            logger.error(f"Failed to parse the shade generate result: {content}")
             return {}  # Return an empty dictionary
 
-        logging.info(f"Shade Generate Result: {shade_raw_info}")
+        logger.info(f"Shade Generate Result: {shade_raw_info}")
 
         raw_shade_info = ShadeInfo(
             name=shade_raw_info.get("domainName", ""),
@@ -186,7 +190,7 @@ Domain Timelines:
         )
         content = response.choices[0].message.content
 
-        logging.info(f"Shade Generate Result: {content}")
+        logger.info(f"Shade Generate Result: {content}")
         return self.__shade_initial_postprocess(content)
 
 
@@ -214,7 +218,7 @@ Domain Timelines:
             model=self.model_name, messages=merge_shades_message, **self.model_params
         )
         content = response.choices[0].message.content
-        logging.info(f"Shade Generate Result: {content}")
+        logger.info(f"Shade Generate Result: {content}")
         return self.__shade_merge_postprocess(content)
 
 
@@ -235,7 +239,7 @@ Domain Timelines:
         if not shade_merge_info:
             raise Exception(f"Failed to parse the shade generate result: {content}")
 
-        logging.info(f"Shade Merge Result: {shade_merge_info}")
+        logger.info(f"Shade Merge Result: {shade_merge_info}")
         merged_shade_info = ShadeInfo(
             name=shade_merge_info.get("newInterestName", ""),
             aspect=shade_merge_info.get("newInterestAspect", ""),
@@ -270,7 +274,7 @@ Domain Timelines:
         if not shade_improve_info:
             raise Exception(f"Failed to parse the shade generate result: {content}")
 
-        logging.info(f"Shade Improve Result: {shade_improve_info}")
+        logger.info(f"Shade Improve Result: {shade_improve_info}")
         old_shade.imporve_shade_info(**shade_improve_info)
         shade_info = self.__add_second_view_info(old_shade)
         return shade_info
@@ -303,7 +307,7 @@ Recent Memories:
             model=self.model_name, messages=shade_improve_message, **self.model_params
         )
         content = response.choices[0].message.content
-        logging.info(f"Shade Generate Result: {content}")
+        logger.info(f"Shade Generate Result: {content}")
         return self.__shade_improve_postprocess(old_shade_info, content)
 
 
@@ -329,30 +333,30 @@ Recent Memories:
         Raises:
             Exception: If input parameters are abnormal.
         """
-        logging.warning(f"shade_info_list: {shade_info_list}")
-        logging.warning(f"old_memory_list: {old_memory_list}")
-        logging.warning(f"new_memory_list: {new_memory_list}")
+        logger.warning(f"shade_info_list: {shade_info_list}")
+        logger.warning(f"old_memory_list: {old_memory_list}")
+        logger.warning(f"new_memory_list: {new_memory_list}")
         
         if not (shade_info_list or old_memory_list):
-            logging.info(
+            logger.info(
                 f"Shades initial Process! Current shade have {len(new_memory_list)} memories!"
             )
             new_shade = self._inital_shade_process(new_memory_list)
         elif shade_info_list and old_memory_list:
             if len(shade_info_list) > 1:
-                logging.info(
+                logger.info(
                     f"Merge shades Process! {len(shade_info_list)} shades need to be merged!"
                 )
                 raw_shade = self._merge_shades_info(old_memory_list, shade_info_list)
             else:
                 raw_shade = shade_info_list[0]
-            logging.info(
+            logger.info(
                 f"Update shade Process! Current shade should improve {len(new_memory_list)} memories!"
             )
             new_shade = self._improve_shade_info(new_memory_list, raw_shade)
         else:
             # Means either shade_info_list or old_memory_list is empty, indicating an abnormal backend input parameter.
-            logging.error(traceback.format_exc())
+            logger.error(traceback.format_exc())
             raise Exception(
                 "The shade_info_list or old_memory_list is empty! Please check the input!"
             )
@@ -493,12 +497,12 @@ class ShadeMerger:
         """
         matches = re.findall(pattern, content, re.DOTALL)
         if not matches:
-            logging.error(f"No Json Found: {content}")
+            logger.error(f"No Json Found: {content}")
             return default_res
         try:
             json_res = json.loads(matches[0])
         except Exception as e:
-            logging.error(f"Json Parse Error: {traceback.format_exc()}-{content}")
+            logger.error(f"Json Parse Error: {traceback.format_exc()}-{content}")
             return default_res
         return json_res
 
@@ -514,13 +518,13 @@ class ShadeMerger:
         """
         try:
             for shade in shade_info_list:
-                logging.info(f"shade: {shade}")
+                logger.info(f"shade: {shade}")
 
             user_prompt = self._build_user_prompt(shade_info_list)
             merge_decision_message = self._build_message(
                 SHADE_MERGE_DEFAULT_SYSTEM_PROMPT, user_prompt
             )
-            logging.info(f"Built merge_decision_message: {merge_decision_message}")
+            logger.info(f"Built merge_decision_message: {merge_decision_message}")
 
             response = self.client.chat.completions.create(
                 model=self.model_name,
@@ -528,11 +532,11 @@ class ShadeMerger:
                 **self.model_params,
             )
             content = response.choices[0].message.content
-            logging.info(f"Shade Merge Decision Result: {content}")
+            logger.info(f"Shade Merge Decision Result: {content}")
 
             try:
                 merge_shade_list = self.__parse_json_response(content, r"\[.*\]")
-                logging.info(f"Parsed merge_shade_list: {merge_shade_list}")
+                logger.info(f"Parsed merge_shade_list: {merge_shade_list}")
             except Exception as e:
                 raise Exception(
                     f"Failed to parse the shade merge list: {content}"
@@ -546,7 +550,7 @@ class ShadeMerger:
                 final_merge_shade_list = []
                 for group in merge_shade_list:
                     shade_ids = group  # Directly use group as it's now a list
-                    logging.info(f"Processing group with shadeIds: {shade_ids}")
+                    logger.info(f"Processing group with shadeIds: {shade_ids}")
                     if not shade_ids:
                         continue
 
@@ -557,7 +561,7 @@ class ShadeMerger:
 
                     # Skip current group if shades is empty
                     if not shades:
-                        logging.info(
+                        logger.info(
                             f"No valid shades found for shadeIds: {shade_ids}. Skipping this group."
                         )
                         continue
@@ -566,7 +570,7 @@ class ShadeMerger:
                     new_cluster_embedd = self._calculate_merged_shades_center_embed(
                         shades
                     )
-                    logging.info(
+                    logger.info(
                         f"Calculated new cluster embedding: {new_cluster_embedd}"
                     )
 
@@ -578,7 +582,7 @@ class ShadeMerger:
             response = ShadeMergeResponse(result=result, success=True)
 
         except Exception as e:
-            logging.error(traceback.format_exc())
+            logger.error(traceback.format_exc())
             response = ShadeMergeResponse(result=str(e), success=False)
 
         return response

--- a/lpm_kernel/L1/shade_generator.py
+++ b/lpm_kernel/L1/shade_generator.py
@@ -27,8 +27,7 @@ from lpm_kernel.configs.config import Config
 
 from lpm_kernel.api.common.script_executor import ScriptExecutor
 
-from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
-setup_logging()
+from lpm_kernel.configs.logging import get_train_process_logger
 logger = get_train_process_logger()
 
 class ShadeGenerator:

--- a/lpm_kernel/L1/topics_generator.py
+++ b/lpm_kernel/L1/topics_generator.py
@@ -3,9 +3,7 @@ from typing import Any, Dict, List, Optional, Union
 import copy
 import itertools
 import json
-import logging
 import math
-import os
 import traceback
 
 from openai import OpenAI
@@ -22,7 +20,9 @@ from lpm_kernel.L1.prompt import (
 from lpm_kernel.L1.utils import find_connected_components
 from lpm_kernel.api.services.user_llm_config_service import UserLLMConfigService
 from lpm_kernel.common.logging import logger
-from lpm_kernel.configs.config import Config
+from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
+setup_logging()
+logger = get_train_process_logger()
 
 
 class TopicsGenerator:

--- a/lpm_kernel/L1/topics_generator.py
+++ b/lpm_kernel/L1/topics_generator.py
@@ -19,9 +19,7 @@ from lpm_kernel.L1.prompt import (
 )
 from lpm_kernel.L1.utils import find_connected_components
 from lpm_kernel.api.services.user_llm_config_service import UserLLMConfigService
-from lpm_kernel.common.logging import logger
-from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
-setup_logging()
+from lpm_kernel.configs.logging import get_train_process_logger
 logger = get_train_process_logger()
 
 

--- a/lpm_kernel/L2/data.py
+++ b/lpm_kernel/L2/data.py
@@ -7,7 +7,6 @@ different formats and extraction of information from notes.
 
 import graphrag
 import json
-import logging
 import os
 import pandas as pd
 import random
@@ -34,6 +33,9 @@ from lpm_kernel.L2.note_templates import OBJECTIVE_TEMPLATES, SUBJECTIVE_TEMPLAT
 from lpm_kernel.L2.utils import format_timestr
 from lpm_kernel.api.services.user_llm_config_service import UserLLMConfigService
 
+from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
+setup_logging()
+logger = get_train_process_logger()
 
 class L2DataProcessor:
     """Data processor for L2 model training.
@@ -99,7 +101,7 @@ class L2DataProcessor:
             file_type="note",
         )
 
-        logging.info("Data refinement completed, preparing to extract entities and relations")
+        logger.info("Data refinement completed, preparing to extract entities and relations")
 
         lang = user_info.get("lang", "English")
 
@@ -164,11 +166,11 @@ class L2DataProcessor:
         selfqa_output_path = os.path.join(data_output_base_dir, selfqa_output_path)
         context_output_path = os.path.join(data_output_base_dir, "context_merged.json")
 
-        logging.info("---" * 30 + "\nPreference data generating\n" + "---" * 30)
+        logger.info("---" * 30 + "\nPreference data generating\n" + "---" * 30)
         self._gen_preference_data(topics_path, preference_output_path, global_bio)
-        logging.info("---" * 30 + "\nPreference data generated\n" + "---" * 30)
+        logger.info("---" * 30 + "\nPreference data generated\n" + "---" * 30)
 
-        logging.info("---" * 30 + "\nDiversity data generating\n" + "---" * 30)
+        logger.info("---" * 30 + "\nDiversity data generating\n" + "---" * 30)
         self._gen_diversity_data(
             entitys_path,
             note_list,
@@ -178,14 +180,14 @@ class L2DataProcessor:
             global_bio,
             config_path,
         )
-        logging.info("---" * 30 + "\nDiversity data generated\n" + "---" * 30)
+        logger.info("---" * 30 + "\nDiversity data generated\n" + "---" * 30)
 
-        logging.info("---" * 30 + "\nSelfQA data generating\n" + "---" * 30)
+        logger.info("---" * 30 + "\nSelfQA data generating\n" + "---" * 30)
         self._gen_selfqa_data(selfqa_output_path, user_name, user_intro, global_bio)
-        logging.info("---" * 30 + "\nSelfQA data generated\n" + "---" * 30)
+        logger.info("---" * 30 + "\nSelfQA data generated\n" + "---" * 30)
 
         if do_context:
-            logging.info("---" * 30 + "\nContext data generating\n" + "---" * 30)
+            logger.info("---" * 30 + "\nContext data generating\n" + "---" * 30)
             self._gen_context_data(
                 note_list,
                 entitys_path,
@@ -194,7 +196,7 @@ class L2DataProcessor:
                 user_intro,
                 global_bio
             )
-            logging.info("---" * 30 + "\nContext data generated\n" + "---" * 30)
+            logger.info("---" * 30 + "\nContext data generated\n" + "---" * 30)
             self._merge_context_data(data_output_base_dir, "context_merged.json")
 
         # Merge the four specified JSON files
@@ -213,7 +215,7 @@ class L2DataProcessor:
                 selfqa_output_path,
             ]
 
-        logging.info("---" * 30 + "\nMerging JSON files\n" + "---" * 30)
+        logger.info("---" * 30 + "\nMerging JSON files\n" + "---" * 30)
 
         for file_path in json_files_to_merge:
             if file_path and os.path.exists(file_path):
@@ -222,24 +224,24 @@ class L2DataProcessor:
                         file_data = json.load(f)
                         if isinstance(file_data, list):
                             merged_data.extend(file_data)
-                            logging.info(f"Added {len(file_data)} items from {file_path}")
+                            logger.info(f"Added {len(file_data)} items from {file_path}")
                         else:
                             merged_data.append(file_data)
-                            logging.info(f"Added 1 item from {file_path}")
+                            logger.info(f"Added 1 item from {file_path}")
                 except Exception as e:
-                    logging.error(f"Error merging file {file_path}: {str(e)}")
+                    logger.error(f"Error merging file {file_path}: {str(e)}")
             else:
                 if file_path == context_output_path and do_context == False:
                     continue
-                logging.warning(f"File not found or path is None: {file_path}")
+                logger.warning(f"File not found or path is None: {file_path}")
 
         # Save the merged data
         merged_output_path = os.path.join(data_output_base_dir, "merged.json")
         with open(merged_output_path, 'w', encoding='utf-8') as f:
             json.dump(merged_data, f, ensure_ascii=False, indent=2)
 
-        logging.info(f"Merged data saved to {merged_output_path} with {len(merged_data)} total items")
-        logging.info("---" * 30 + "\nJSON files merged\n" + "---" * 30)
+        logger.info(f"Merged data saved to {merged_output_path} with {len(merged_data)} total items")
+        logger.info("---" * 30 + "\nJSON files merged\n" + "---" * 30)
 
     def _merge_context_data(self, data_output_base_dir: str, context_merged_file_name: str):
         """Merge context_enhanced.json and context_final.jsonl files.
@@ -248,7 +250,7 @@ class L2DataProcessor:
             data_output_base_dir: Base directory containing the files to merge.
             context_merged_file_name: Name of the output merged file.
         """
-        logging.info("---" * 30 + "\nMerging context files\n" + "---" * 30)
+        logger.info("---" * 30 + "\nMerging context files\n" + "---" * 30)
 
         result = []
 
@@ -266,10 +268,10 @@ class L2DataProcessor:
                         "enhanced_request": enhanced_need["enhanced_request"]
                     })
                 except (json.JSONDecodeError, KeyError) as e:
-                    logging.warning(f"Failed to process enhanced item: {str(e)}")
+                    logger.warning(f"Failed to process enhanced item: {str(e)}")
                     continue
         except Exception as e:
-            logging.error(f"Error processing context_enhanced.json: {str(e)}")
+            logger.error(f"Error processing context_enhanced.json: {str(e)}")
 
         # Process context_final.jsonl
         try:
@@ -292,21 +294,21 @@ class L2DataProcessor:
                                 response['feedback'][0]
                             })
                         except (json.JSONDecodeError, KeyError) as e:
-                            logging.warning(f"Failed to process final item response: {str(e)}")
+                            logger.warning(f"Failed to process final item response: {str(e)}")
                             continue
                     except json.JSONDecodeError as e:
-                        logging.warning(f"Failed to parse line as JSON: {str(e)}")
+                        logger.warning(f"Failed to parse line as JSON: {str(e)}")
                         continue
         except Exception as e:
-            logging.error(f"Error processing context_final.jsonl: {str(e)}")
+            logger.error(f"Error processing context_final.jsonl: {str(e)}")
 
         # Save the merged results
         output_path = f"{data_output_base_dir}/{context_merged_file_name}"
         with open(output_path, 'w', encoding='utf-8') as f:
             json.dump(result, f, ensure_ascii=False, indent=2)
 
-        logging.info(f"Merged context files saved to {output_path}")
-        logging.info("---" * 30 + "\nContext files merged\n" + "---" * 30)
+        logger.info(f"Merged context files saved to {output_path}")
+        logger.info("---" * 30 + "\nContext files merged\n" + "---" * 30)
 
     def split_notes_by_type(self, note_list: List[Note], basic_info: Dict):
         """Split notes into subjective and objective categories.
@@ -334,9 +336,9 @@ class L2DataProcessor:
             elif note.memory_type in OBJECT_NOTE_TYPE:
                 objective_notes.append(note)
             else:
-                logging.warning(f"Note type not supported: {note.memory_type}")
+                logger.warning(f"Note type not supported: {note.memory_type}")
                 continue
-        logging.info(
+        logger.info(
             f"Subjective notes: {len(subjective_notes)}, Objective notes: {len(objective_notes)}"
         )
         return user_info, subjective_notes, objective_notes
@@ -381,7 +383,7 @@ class L2DataProcessor:
 
                 data_filtered.append(note)
 
-        logging.info(f"Refined subjective notes: {len(data_filtered)}")
+        logger.info(f"Refined subjective notes: {len(data_filtered)}")
 
         json_data_filted = [o.to_json() for o in data_filtered]
         file_dir = os.path.dirname(json_file_remade)
@@ -425,7 +427,7 @@ class L2DataProcessor:
                     ).format(insight=note.insight)
                 new_item_list.append(new_item)
 
-        logging.info(f"Refined objective notes: {len(new_item_list)}")
+        logger.info(f"Refined objective notes: {len(new_item_list)}")
 
         file_dir = os.path.dirname(json_file_remade)
         if not os.path.exists(file_dir):
@@ -448,8 +450,8 @@ class L2DataProcessor:
         # Ensure the target directory exists
         if not os.path.exists(txt_file_base):
             os.makedirs(txt_file_base)
-            logging.warning("Currently running in function json_to_txt_each")
-            logging.warning(f"Specified directory does not exist, created: {txt_file_base}")
+            logger.warning("Currently running in function json_to_txt_each")
+            logger.warning(f"Specified directory does not exist, created: {txt_file_base}")
 
         # Clear all existing files in the target directory
         for existing_file in os.listdir(txt_file_base):
@@ -457,11 +459,11 @@ class L2DataProcessor:
             if os.path.isfile(file_path):
                 try:
                     os.remove(file_path)
-                    logging.info(f"Removed existing file: {file_path}")
+                    logger.info(f"Removed existing file: {file_path}")
                 except Exception as e:
-                    logging.error(f"Error removing file {file_path}: {str(e)}")
+                    logger.error(f"Error removing file {file_path}: {str(e)}")
 
-        logging.info(f"Cleared all existing files in {txt_file_base}")
+        logger.info(f"Cleared all existing files in {txt_file_base}")
 
         for no, item in enumerate(tqdm(list_processed_notes)):
             # Build the txt file path
@@ -472,10 +474,10 @@ class L2DataProcessor:
                     with open(txt_file, "w", encoding="utf-8") as tf:
                         tf.write(item.processed)
                 else:
-                    logging.warning(f"Warning: 'processed' key missing for item {no}")
+                    logger.warning(f"Warning: 'processed' key missing for item {no}")
 
             except Exception as e:
-                logging.error(traceback.format_exc())
+                logger.error(traceback.format_exc())
 
     def graphrag_indexing(
             self, note_list: List[Note], graph_input_dir: str, output_dir: str, lang: str
@@ -535,14 +537,14 @@ class L2DataProcessor:
 
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
-            logging.warning(f"Specified output directory does not exist, created: {output_dir}.")
+            logger.warning(f"Specified output directory does not exist, created: {output_dir}.")
 
         with open(GRAPH_CONFIG, "w", encoding="utf-8") as file:
             yaml.dump(settings, file, default_flow_style=False, allow_unicode=True)
 
-        logging.info(f"Input base_dir has been updated to {graph_input_dir} and saved.")
-        logging.info(f"Output base_dir has been updated to {output_dir} and saved.")
-        logging.info(
+        logger.info(f"Input base_dir has been updated to {graph_input_dir} and saved.")
+        logger.info(f"Output base_dir has been updated to {output_dir} and saved.")
+        logger.info(
             f"Report base_dir has been updated to {os.path.join(output_dir, 'report')} and saved."
         )
 
@@ -611,9 +613,9 @@ class L2DataProcessor:
         json_data = []
 
         # show the column names
-        logging.info(f"Entity Column names: {entities.columns}")
+        logger.info(f"Entity Column names: {entities.columns}")
 
-        logging.info(f"Document Column names: {document.columns}")
+        logger.info(f"Document Column names: {document.columns}")
 
         for e_i, e_r in tqdm(entities.iterrows(), total=len(entities)):
             json_item = {}
@@ -737,8 +739,8 @@ class L2DataProcessor:
             data_output_base_dir=data_output_base_dir,
             needs_file_name="context_needs.json"
         )
-        logging.info("---" * 30 + "\nContext needs generated\n" + "---" * 30)
-        logging.info(data_output_base_dir + "/context_needs.json")
+        logger.info("---" * 30 + "\nContext needs generated\n" + "---" * 30)
+        logger.info(data_output_base_dir + "/context_needs.json")
 
         # 2. Generate context enhanced data
         context_generator.generate_context_enhance_data(
@@ -747,8 +749,8 @@ class L2DataProcessor:
             context_enhanced_res_file_name="context_enhanced.json",
             note_list=note_list
         )
-        logging.info("---" * 30 + "\nContext enhanced generated\n" + "---" * 30)
-        logging.info(data_output_base_dir + "/context_enhanced.json")
+        logger.info("---" * 30 + "\nContext enhanced generated\n" + "---" * 30)
+        logger.info(data_output_base_dir + "/context_enhanced.json")
 
         # 3. Generate expert responses
         context_generator.expert_response_generator(
@@ -756,8 +758,8 @@ class L2DataProcessor:
             context_enhanced_res_file_name="context_enhanced.json",
             output_file_name="expert_responses.json"
         )
-        logging.info("---" * 30 + "\nExpert responses generated\n" + "---" * 30)
-        logging.info(data_output_base_dir + "/expert_responses.json")
+        logger.info("---" * 30 + "\nExpert responses generated\n" + "---" * 30)
+        logger.info(data_output_base_dir + "/expert_responses.json")
 
         # 4. Generate expert responses and critic data
         context_generator.gen_context_critic_data(
@@ -765,5 +767,5 @@ class L2DataProcessor:
             expert_response_file_name="expert_responses.json",
             out_file_name="context_final.jsonl"
         )
-        logging.info("---" * 30 + "\nContext critic generated\n" + "---" * 30)
-        logging.info(data_output_base_dir + "/context_final.jsonl")
+        logger.info("---" * 30 + "\nContext critic generated\n" + "---" * 30)
+        logger.info(data_output_base_dir + "/context_final.jsonl")

--- a/lpm_kernel/L2/data.py
+++ b/lpm_kernel/L2/data.py
@@ -33,8 +33,7 @@ from lpm_kernel.L2.note_templates import OBJECTIVE_TEMPLATES, SUBJECTIVE_TEMPLAT
 from lpm_kernel.L2.utils import format_timestr
 from lpm_kernel.api.services.user_llm_config_service import UserLLMConfigService
 
-from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
-setup_logging()
+from lpm_kernel.configs.logging import get_train_process_logger
 logger = get_train_process_logger()
 
 class L2DataProcessor:

--- a/lpm_kernel/L2/data_pipeline/data_prep/diversity/diversity_data_generator.py
+++ b/lpm_kernel/L2/data_pipeline/data_prep/diversity/diversity_data_generator.py
@@ -14,8 +14,7 @@ from lpm_kernel.configs.config import Config
 from lpm_kernel.L2.data_pipeline.data_prep.diversity.utils import remove_similar_dicts
 import lpm_kernel.L2.data_pipeline.data_prep.diversity.template_diversity as template_diversity
 
-from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
-setup_logging()
+from lpm_kernel.configs.logging import get_train_process_logger
 logger = get_train_process_logger()
 
 

--- a/lpm_kernel/L2/data_pipeline/data_prep/diversity/diversity_data_generator.py
+++ b/lpm_kernel/L2/data_pipeline/data_prep/diversity/diversity_data_generator.py
@@ -1,6 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
 import json
-import logging
 import os
 import random
 import re
@@ -14,6 +13,10 @@ from lpm_kernel.api.services.user_llm_config_service import UserLLMConfigService
 from lpm_kernel.configs.config import Config
 from lpm_kernel.L2.data_pipeline.data_prep.diversity.utils import remove_similar_dicts
 import lpm_kernel.L2.data_pipeline.data_prep.diversity.template_diversity as template_diversity
+
+from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
+setup_logging()
+logger = get_train_process_logger()
 
 
 class DiversityDataGenerator:
@@ -226,7 +229,7 @@ class DiversityDataGenerator:
 
         # global questions, only process clusters with more than 8 notes, and split very large clusters
         large_clusters = [item for item in entity2desc_list if len(item["note"]) >= 8]
-        logging.info(f"Large clusters: {len(large_clusters)}")
+        logger.info(f"Large clusters: {len(large_clusters)}")
 
         exploded_clusters = []
         # split
@@ -257,12 +260,12 @@ class DiversityDataGenerator:
             if len(item["note"]) < 8 and len(item["note"]) > 1
         ]
 
-        logging.info(f"Mini clusters: {len(mini_clusters)}")
+        logger.info(f"Mini clusters: {len(mini_clusters)}")
 
         # process other clusters
         tiny_clusters = [item for item in entity2desc_list if len(item["note"]) <= 1]
 
-        logging.info(f"Tiny clusters: {len(tiny_clusters)}")
+        logger.info(f"Tiny clusters: {len(tiny_clusters)}")
 
         filtered_tiny_clusters = [
             d
@@ -271,40 +274,40 @@ class DiversityDataGenerator:
             in ["PERSON", "人", "组织", "ORGANIZATION", "人物"]
         ]
 
-        logging.info(f"Filtered tiny clusters: {len(filtered_tiny_clusters)}")
+        logger.info(f"Filtered tiny clusters: {len(filtered_tiny_clusters)}")
 
         if len(exploded_clusters) > 0:
-            logging.info("Execute large cluster generation")
+            logger.info("Execute large cluster generation")
             data_large = self._pipline(exploded_clusters, 4, q_dict, templater, language_desc, user_name)
         else:
-            logging.info("Large cluster number is 0")
+            logger.info("Large cluster number is 0")
             data_large = []
 
         if len(mini_clusters) > 0:
-            logging.info("Execute small cluster generation")
+            logger.info("Execute small cluster generation")
             data_mini = self._pipline(mini_clusters, 3, q_dict, templater, language_desc, user_name)
         else:
-            logging.info("Small cluster number is 0")
+            logger.info("Small cluster number is 0")
             data_mini = []
 
         if len(filtered_tiny_clusters) > 0:
-            logging.info("Execute single entity cluster generation")
+            logger.info("Execute single entity cluster generation")
             q_dict.pop("unanswerable")
             q_dict.pop("global")
             data_tiny = self._pipline(filtered_tiny_clusters, 2, q_dict, templater, language_desc, user_name)
         else:
-            logging.info("Single entity cluster number is 0")
+            logger.info("Single entity cluster number is 0")
             data_tiny = []
 
         combined_list = data_large + data_mini + data_tiny
         # calculate total entries
         total_entries = len(combined_list)
-        logging.info(f"Total entries: {total_entries}")
+        logger.info(f"Total entries: {total_entries}")
         # store data
         with open(output_path, "w", encoding="utf-8") as f:
             json.dump(combined_list, f, ensure_ascii=False, indent=4)
 
-        logging.info(f"Data has been stored to {output_path}")
+        logger.info(f"Data has been stored to {output_path}")
 
 
     def _pipline(self, clusters: list, aug_para: int, q_dict: dict, 
@@ -332,9 +335,9 @@ class DiversityDataGenerator:
             random_types = random.choices(list(q_dict.keys()), weights, k=aug_para)
             explode_questions_types.extend(random_types)
 
-        logging.info("Start generating data")
-        logging.info(f"Explode clusters: {len(explode_clusters)}")
-        logging.info(f"Explode questions types: {len(explode_questions_types)}")
+        logger.info("Start generating data")
+        logger.info(f"Explode clusters: {len(explode_clusters)}")
+        logger.info(f"Explode questions types: {len(explode_questions_types)}")
 
         questions, answers, answer_types, flat_question_types, flat_clusters = self._generate(
             explode_clusters, explode_questions_types, templater, q_dict, language_desc, user_name
@@ -400,10 +403,10 @@ class DiversityDataGenerator:
                     flat_clusters.extend([cluster] * len(result))
                     flat_question_types.extend([question_type] * len(result))
                 except Exception as e:
-                    logging.error(traceback.format_exc())
+                    logger.error(traceback.format_exc())
 
         # safety check
-        logging.info(f"Count: {cnt}, len(explode_clusters): {len(explode_clusters)}")
+        logger.info(f"Count: {cnt}, len(explode_clusters): {len(explode_clusters)}")
 
         with ThreadPoolExecutor(max_workers=2) as executor:
             futures = [
@@ -422,7 +425,7 @@ class DiversityDataGenerator:
                     answers.append(result)
                     answer_types.append(answer_type)
                 except Exception as e:
-                    logging.error(traceback.format_exc())
+                    logger.error(traceback.format_exc())
 
         return questions, answers, answer_types, flat_question_types, flat_clusters
 
@@ -465,7 +468,7 @@ class DiversityDataGenerator:
             pattern = r"Question\s*\d+\s*:\s*(.*?)\|\|"
             questions = re.findall(pattern, res + "||")
         except Exception as e:
-            logging.error(traceback.format_exc())
+            logger.error(traceback.format_exc())
             questions = []
             return questions
 

--- a/lpm_kernel/L2/data_pipeline/data_prep/diversity/diversity_data_generator.py
+++ b/lpm_kernel/L2/data_pipeline/data_prep/diversity/diversity_data_generator.py
@@ -1,6 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor
 import json
 import os
+import logging
 import random
 import re
 import traceback
@@ -16,6 +17,19 @@ import lpm_kernel.L2.data_pipeline.data_prep.diversity.template_diversity as tem
 
 from lpm_kernel.configs.logging import get_train_process_logger
 logger = get_train_process_logger()
+
+
+class TqdmLoggingHandler:
+    def __init__(self):
+        pass
+    
+    def write(self, msg):
+        logger.info(msg.strip())
+    
+    def flush(self):
+        pass
+    
+tqdm_handler = TqdmLoggingHandler()
 
 
 class DiversityDataGenerator:
@@ -389,7 +403,7 @@ class DiversityDataGenerator:
             flat_question_types = []
             cnt = 0
             for future, cluster, question_type in zip(
-                tqdm(futures, total=len(futures), desc="Q_generate"),
+                tqdm(futures, total=len(futures), desc="Q_generate", file=tqdm_handler),
                 explode_clusters,
                 explode_questions_types,
             ):
@@ -418,7 +432,7 @@ class DiversityDataGenerator:
             answers = []
             answer_types = []
 
-            for future in tqdm(futures, total=len(futures), desc="A_generate"):
+            for future in tqdm(futures, total=len(futures), desc="A_generate", file=tqdm_handler):
                 try:
                     result, answer_type = future.result()
                     answers.append(result)

--- a/lpm_kernel/L2/train.py
+++ b/lpm_kernel/L2/train.py
@@ -31,6 +31,9 @@ from lpm_kernel.L2.utils import (
 )
 from lpm_kernel.configs.logging import LOGGING_CONFIG
 import logging.config
+from lpm_kernel.configs.logging import get_train_process_logger
+logger = get_train_process_logger()
+
 
 # Configure how tqdm displays in logs
 class LogTqdm(tqdm):
@@ -42,7 +45,6 @@ class LogTqdm(tqdm):
 # Replace the default tqdm
 sys.modules["tqdm"].tqdm = LogTqdm
 
-logger = logging.getLogger(__name__)
 
 @dataclass
 class ModelArguments:

--- a/lpm_kernel/L2/train.py
+++ b/lpm_kernel/L2/train.py
@@ -1,6 +1,5 @@
 from transformers import TrainingArguments, AutoTokenizer, AutoModelForCausalLM
 import torch
-import logging
 from tqdm import tqdm
 import functools
 # Standard library imports
@@ -29,8 +28,8 @@ from lpm_kernel.L2.utils import (
     formatting_prompts_func,
     create_chat_data,
 )
-from lpm_kernel.configs.logging import LOGGING_CONFIG
-import logging.config
+from lpm_kernel.configs.logger import logger_CONFIG
+import logger.config
 
 # Configure how tqdm displays in logs
 class LogTqdm(tqdm):
@@ -42,7 +41,9 @@ class LogTqdm(tqdm):
 # Replace the default tqdm
 sys.modules["tqdm"].tqdm = LogTqdm
 
-logger = logging.getLogger(__name__)
+from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
+setup_logging()
+logger = get_train_process_logger()
 
 @dataclass
 class ModelArguments:
@@ -151,13 +152,13 @@ class DataTrainingArguments:
 def main(model_args, data_args, training_args):
     logger.info(f"Python version--------------------: {sys.version}")
 
-    # Configure logging
-    logging.config.dictConfig(LOGGING_CONFIG)
+    # Configure logger
+    logger.config.dictConfig(logger_CONFIG)
 
     logger.info("Begin training...")
 
     # Ensure logs are flushed immediately
-    for handler in logging.getLogger().handlers:
+    for handler in logger.getLogger().handlers:
         handler.flush()
 
     logger.info("start 1")

--- a/lpm_kernel/L2/train.py
+++ b/lpm_kernel/L2/train.py
@@ -1,5 +1,6 @@
 from transformers import TrainingArguments, AutoTokenizer, AutoModelForCausalLM
 import torch
+import logging
 from tqdm import tqdm
 import functools
 # Standard library imports
@@ -28,8 +29,8 @@ from lpm_kernel.L2.utils import (
     formatting_prompts_func,
     create_chat_data,
 )
-from lpm_kernel.configs.logger import logger_CONFIG
-import logger.config
+from lpm_kernel.configs.logging import LOGGING_CONFIG
+import logging.config
 
 # Configure how tqdm displays in logs
 class LogTqdm(tqdm):
@@ -41,9 +42,7 @@ class LogTqdm(tqdm):
 # Replace the default tqdm
 sys.modules["tqdm"].tqdm = LogTqdm
 
-from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
-setup_logging()
-logger = get_train_process_logger()
+logger = logging.getLogger(__name__)
 
 @dataclass
 class ModelArguments:
@@ -152,13 +151,13 @@ class DataTrainingArguments:
 def main(model_args, data_args, training_args):
     logger.info(f"Python version--------------------: {sys.version}")
 
-    # Configure logger
-    logger.config.dictConfig(logger_CONFIG)
+    # Configure logging
+    logging.config.dictConfig(LOGGING_CONFIG)
 
     logger.info("Begin training...")
 
     # Ensure logs are flushed immediately
-    for handler in logger.getLogger().handlers:
+    for handler in logging.getLogger().handlers:
         handler.flush()
 
     logger.info("start 1")

--- a/lpm_kernel/L2/utils.py
+++ b/lpm_kernel/L2/utils.py
@@ -22,6 +22,7 @@ from transformers import (
 import tiktoken
 import torch
 import logging
+from lpm_kernel.configs.logging import TRAIN_LOG_FILE
 
 from lpm_kernel.L2.training_prompt import (
     CONTEXT_PROMPT,
@@ -334,11 +335,6 @@ def setup_logger(log_path, logger_name="download_logger"):
     
     return logger
 
-def get_default_log_path():
-    """Get the default log file path."""
-    log_dir = os.path.join(os.getcwd(), "logs")
-    os.makedirs(log_dir, exist_ok=True)
-    return os.path.join(log_dir, "model_download.log")
 
 def save_hf_model(model_name="Qwen2.5-0.5B-Instruct", log_file_path=None) -> str:
     """Saves a Hugging Face model locally.
@@ -352,7 +348,7 @@ def save_hf_model(model_name="Qwen2.5-0.5B-Instruct", log_file_path=None) -> str
     """
     # If log_file_path is None or empty, use default path
     if not log_file_path:
-        log_file_path = get_default_log_path()
+        log_file_path = TRAIN_LOG_FILE
     
     # Setup logging
     logger = setup_logger(log_file_path)

--- a/lpm_kernel/api/common/script_runner.py
+++ b/lpm_kernel/api/common/script_runner.py
@@ -4,8 +4,7 @@ import time
 import subprocess
 from typing import Optional, Dict, Any
 
-from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
-setup_logging()
+from lpm_kernel.configs.logging import get_train_process_logger
 logger = get_train_process_logger()
 
 
@@ -104,7 +103,7 @@ class ScriptRunner:
             from subprocess import PIPE
             
             # Open log file
-            with open(log_file, "w", buffering=1) as f:
+            with open(log_file, "a", buffering=1) as f:
                 process = subprocess.Popen(
                     command,
                     shell=False,  # Use list form of command, no need for shell=True

--- a/lpm_kernel/api/common/script_runner.py
+++ b/lpm_kernel/api/common/script_runner.py
@@ -1,11 +1,12 @@
 import os
 import sys
 import time
-import logging
 import subprocess
 from typing import Optional, Dict, Any
 
-logger = logging.getLogger(__name__)
+from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
+setup_logging()
+logger = get_train_process_logger()
 
 
 class ScriptRunner:

--- a/lpm_kernel/api/domains/trainprocess/routes.py
+++ b/lpm_kernel/api/domains/trainprocess/routes.py
@@ -9,8 +9,7 @@ from .progress import Status
 from ...common.responses import APIResponse
 from threading import Thread
 
-from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
-setup_logging()
+from lpm_kernel.configs.logging import get_train_process_logger
 logger = get_train_process_logger()
 
 trainprocess_bp = Blueprint("trainprocess", __name__, url_prefix="/api/trainprocess")
@@ -124,7 +123,7 @@ def start_process():
 @trainprocess_bp.route("/logs", methods=["GET"])
 def stream_logs():
     """Get training logs in real-time"""
-    log_file_path = "logs/backend.log"  # Log file path
+    log_file_path = "logs/train/train.log"  # Log file path
     last_position = 0
     
     # Define keywords to exclude

--- a/lpm_kernel/api/domains/trainprocess/routes.py
+++ b/lpm_kernel/api/domains/trainprocess/routes.py
@@ -125,12 +125,6 @@ def stream_logs():
     """Get training logs in real-time"""
     log_file_path = "logs/train/train.log"  # Log file path
     last_position = 0
-    
-    # Define keywords to exclude
-    exclude_keywords = [
-        "GET /api"
-    ]
-
     def generate_logs():
         nonlocal last_position
         while True:
@@ -143,11 +137,7 @@ def stream_logs():
                         # Skip empty lines
                         if not line.strip():
                             continue
-                            
-                        # Check if the line contains any of the exclude keywords
-                        if any(exclude_word in line for exclude_word in exclude_keywords):
-                            continue
-                            
+                        
                         yield f"data: {line.strip()}\n\n"
                             
                     last_position = log_file.tell()

--- a/lpm_kernel/api/domains/trainprocess/routes.py
+++ b/lpm_kernel/api/domains/trainprocess/routes.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import time
 from pathlib import Path
 
@@ -9,6 +8,10 @@ from lpm_kernel.file_data.trainprocess_service import TrainProcessService
 from .progress import Status
 from ...common.responses import APIResponse
 from threading import Thread
+
+from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
+setup_logging()
+logger = get_train_process_logger()
 
 trainprocess_bp = Blueprint("trainprocess", __name__, url_prefix="/api/trainprocess")
 
@@ -32,7 +35,7 @@ def progress_callback(progress_update):
         if stage and step:
             progress.update_progress(stage, step, status, prog)
     except Exception as e:
-        logging.error(f"Progress callback error: {str(e)}")
+        logger.error(f"Progress callback error: {str(e)}")
 
 
 def clear_specific_logs():
@@ -47,7 +50,7 @@ def clear_specific_logs():
                 with open(log_file, 'w') as f:
                     f.truncate(0)
             except Exception as e:
-                logging.error(f"Failed to clear log file {log_file}: {e}")
+                logger.error(f"Failed to clear log file {log_file}: {e}")
 
 
 @trainprocess_bp.route("/start", methods=["POST"])
@@ -83,7 +86,7 @@ def start_process():
             }
         }
     """
-    logging.info("Training process starting...")  # Log the startup
+    logger.info("Training process starting...")  # Log the startup
     try:
         data = request.get_json()
         if not data or "model_name" not in data:
@@ -114,7 +117,7 @@ def start_process():
         )
     
     except Exception as e:
-        logging.error(f"Training process failed: {str(e)}")
+        logger.error(f"Training process failed: {str(e)}")
         return jsonify(APIResponse.error(message=f"Training process error: {str(e)}"))
 
 
@@ -202,7 +205,7 @@ def reset_progress():
 
         return jsonify(APIResponse.success(message="Progress reset successfully"))
     except Exception as e:
-        logging.error(f"Reset progress failed: {str(e)}")
+        logger.error(f"Reset progress failed: {str(e)}")
         return jsonify(APIResponse.error(message=f"Failed to reset progress: {str(e)}"))
 
 
@@ -234,7 +237,7 @@ def stop_training():
             time.sleep(wait_interval)
 
     except Exception as e:
-        logging.error(f"Error stopping training process: {str(e)}")
+        logger.error(f"Error stopping training process: {str(e)}")
         return jsonify(APIResponse.error(message=f"Error stopping training process: {str(e)}"))
 
 
@@ -260,7 +263,7 @@ def get_model_name():
         
         return jsonify(APIResponse.success(data={"model_name": model_name}))
     except Exception as e:
-        logging.error(f"Failed to get model name: {str(e)}")
+        logger.error(f"Failed to get model name: {str(e)}")
         return jsonify(APIResponse.error(message=f"Failed to get model name: {str(e)}"))
 
 
@@ -314,5 +317,5 @@ def retrain():
             )
         )
     except Exception as e:
-        logging.error(f"Retrain reset failed: {str(e)}")
+        logger.error(f"Retrain reset failed: {str(e)}")
         return jsonify(APIResponse.error(message=f"Failed to reset progress to data processing stage: {str(e)}"))

--- a/lpm_kernel/common/llm.py
+++ b/lpm_kernel/common/llm.py
@@ -3,8 +3,7 @@ from lpm_kernel.configs.config import Config
 from typing import List, Union
 import requests
 import numpy as np
-from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
-setup_logging()
+from lpm_kernel.configs.logging import get_train_process_logger
 logger = get_train_process_logger()
 
 

--- a/lpm_kernel/common/llm.py
+++ b/lpm_kernel/common/llm.py
@@ -1,9 +1,11 @@
 from lpm_kernel.api.services.user_llm_config_service import UserLLMConfigService
 from lpm_kernel.configs.config import Config
 from typing import List, Union
-from lpm_kernel.common.logging import logger
 import requests
 import numpy as np
+from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
+setup_logging()
+logger = get_train_process_logger()
 
 
 class LLMClient:

--- a/lpm_kernel/common/logging.py
+++ b/lpm_kernel/common/logging.py
@@ -3,17 +3,22 @@ import logging
 import logging.config
 import os
 import sys
-from lpm_kernel.configs.logging import LOGGING_CONFIG, DEFAULT_LOG_DIR
+from lpm_kernel.configs.logging import LOGGING_CONFIG, LOG_BASE_DIR, TRAIN_LOG_DIR, rename_existing_log_file
 
 
 def setup_logging():
     try:
-        # Ensure log directory exists
-        os.makedirs(DEFAULT_LOG_DIR, exist_ok=True)
+        # Ensure log directories exist
+        os.makedirs(LOG_BASE_DIR, exist_ok=True)
+        os.makedirs(TRAIN_LOG_DIR, exist_ok=True)
+        
+        # Rename existing log file if needed
+        rename_existing_log_file()
         # Ensure directory permissions are correct
-        os.chmod(DEFAULT_LOG_DIR, 0o755)
+        os.chmod(TRAIN_LOG_DIR, 0o755)
+        os.chmod(LOG_BASE_DIR, 0o755)
 
-        print(f"Log directory: {DEFAULT_LOG_DIR}", file=sys.stderr)
+        print(f"Log directory: {TRAIN_LOG_DIR}", file=sys.stderr)
         print(
             f"Log file: {LOGGING_CONFIG['handlers']['file']['filename']}",
             file=sys.stderr,
@@ -51,9 +56,3 @@ def setup_logging():
 
 # Initialize global logger
 logger = setup_logging()
-
-# Test logging
-logger.debug("DEBUG: Logging module loaded")
-logger.info("INFO: Logging module loaded")
-logger.warning("WARNING: Logging module loaded")
-logger.error("ERROR: Logging module loaded")

--- a/lpm_kernel/configs/logging.py
+++ b/lpm_kernel/configs/logging.py
@@ -67,7 +67,7 @@ LOGGING_CONFIG = {
     "loggers": {
         "train_process": {
             "level": "INFO",
-            "handlers": ["train_process_file"],
+            "handlers": ["train_process_file", "console"],
             "propagate": False,
         },
     },

--- a/lpm_kernel/configs/logging.py
+++ b/lpm_kernel/configs/logging.py
@@ -1,5 +1,10 @@
 import os
 import sys
+import logging
+import logging.config
+import logging.handlers
+import datetime
+import shutil
 
 # Get project root directory
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
@@ -13,6 +18,20 @@ log_file_path = os.path.join(DEFAULT_LOG_DIR, "app.log")
 with open(log_file_path, "w") as f:
     pass  # Clear log file content
 
+# 定义日志文件路径
+APP_LOG_FILE = os.path.join(DEFAULT_LOG_DIR, "app.log")
+
+# 在模块加载时生成日志文件路径
+TRAIN_LOG_FILENAME = "train.log"
+TRAIN_PROCESS_LOG_FILE = os.path.join(DEFAULT_LOG_DIR, TRAIN_LOG_FILENAME)
+
+# 检查train.log是否存在，如果存在则重命名
+if os.path.exists(TRAIN_PROCESS_LOG_FILE):
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_filename = f"train_{timestamp}.log"
+    backup_path = os.path.join(DEFAULT_LOG_DIR, backup_filename)
+    shutil.move(TRAIN_PROCESS_LOG_FILE, backup_path)
+    print(f"Existing train.log renamed to {backup_filename}")
 
 LOGGING_CONFIG = {
     "version": 1,
@@ -34,10 +53,26 @@ LOGGING_CONFIG = {
             "class": "logging.handlers.RotatingFileHandler",
             "level": "INFO",
             "formatter": "standard",
-            "filename": os.path.join(DEFAULT_LOG_DIR, "app.log"),
+            "filename": APP_LOG_FILE,
             "maxBytes": 10485760,  # 10MB
             "backupCount": 5,
             "encoding": "utf-8",
+        },
+        "train_process_file": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "level": "INFO",
+            "formatter": "standard",
+            "filename": TRAIN_PROCESS_LOG_FILE,
+            "maxBytes": 10485760,  # 10MB
+            "backupCount": 5,
+            "encoding": "utf-8",
+        },
+    },
+    "loggers": {
+        "train_process": {
+            "level": "INFO",
+            "handlers": ["train_process_file"],
+            "propagate": False,
         },
     },
     "root": {  # root logger configuration
@@ -45,3 +80,11 @@ LOGGING_CONFIG = {
         "handlers": ["console", "file"],
     },
 }
+
+# 初始化日志配置
+def setup_logging():
+    logging.config.dictConfig(LOGGING_CONFIG)
+
+# 获取训练过程日志器
+def get_train_process_logger():
+    return logging.getLogger("train_process")

--- a/lpm_kernel/configs/logging.py
+++ b/lpm_kernel/configs/logging.py
@@ -8,30 +8,26 @@ import shutil
 
 # Get project root directory
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
-DEFAULT_LOG_DIR = os.path.join(PROJECT_ROOT, "logs")
 
-# Ensure log directory exists
-os.makedirs(DEFAULT_LOG_DIR, exist_ok=True)
+# Define log directories
+LOG_BASE_DIR = os.path.join(PROJECT_ROOT, "logs")
+TRAIN_LOG_DIR = os.path.join(LOG_BASE_DIR, "train")
 
-# Clear log file
-log_file_path = os.path.join(DEFAULT_LOG_DIR, "app.log")
-with open(log_file_path, "w") as f:
-    pass  # Clear log file content
+# Define log file paths
+APP_LOG_FILE = os.path.join(LOG_BASE_DIR, "app.log")
+TRAIN_LOG_FILE = os.path.join(TRAIN_LOG_DIR, "train.log")
 
-# 定义日志文件路径
-APP_LOG_FILE = os.path.join(DEFAULT_LOG_DIR, "app.log")
-
-# 在模块加载时生成日志文件路径
-TRAIN_LOG_FILENAME = "train.log"
-TRAIN_PROCESS_LOG_FILE = os.path.join(DEFAULT_LOG_DIR, TRAIN_LOG_FILENAME)
-
-# 检查train.log是否存在，如果存在则重命名
-if os.path.exists(TRAIN_PROCESS_LOG_FILE):
-    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-    backup_filename = f"train_{timestamp}.log"
-    backup_path = os.path.join(DEFAULT_LOG_DIR, backup_filename)
-    shutil.move(TRAIN_PROCESS_LOG_FILE, backup_path)
-    print(f"Existing train.log renamed to {backup_filename}")
+# Function to rename log file if it exists
+def rename_existing_log_file():
+    if os.path.exists(TRAIN_LOG_FILE):
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        backup_filename = f"train_{timestamp}.log"
+        backup_path = os.path.join(TRAIN_LOG_DIR, backup_filename)
+        
+        shutil.move(TRAIN_LOG_FILE, backup_path)
+        print(f"Existing train.log renamed to {backup_filename}")
+        return True
+    return False
 
 LOGGING_CONFIG = {
     "version": 1,
@@ -62,7 +58,7 @@ LOGGING_CONFIG = {
             "class": "logging.handlers.RotatingFileHandler",
             "level": "INFO",
             "formatter": "standard",
-            "filename": TRAIN_PROCESS_LOG_FILE,
+            "filename": TRAIN_LOG_FILE,
             "maxBytes": 10485760,  # 10MB
             "backupCount": 5,
             "encoding": "utf-8",
@@ -81,10 +77,10 @@ LOGGING_CONFIG = {
     },
 }
 
-# 初始化日志配置
+# Initialize logging configuration
 def setup_logging():
     logging.config.dictConfig(LOGGING_CONFIG)
 
-# 获取训练过程日志器
+# Get train process logger
 def get_train_process_logger():
     return logging.getLogger("train_process")

--- a/lpm_kernel/file_data/chunker.py
+++ b/lpm_kernel/file_data/chunker.py
@@ -1,11 +1,12 @@
 from typing import List
 from lpm_kernel.L1.bio import Chunk
-import logging
 import traceback
 import time
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 
-logger = logging.getLogger(__name__)
+from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
+setup_logging()
+logger = get_train_process_logger()
 
 
 class DocumentChunker:

--- a/lpm_kernel/file_data/chunker.py
+++ b/lpm_kernel/file_data/chunker.py
@@ -4,8 +4,7 @@ import traceback
 import time
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 
-from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
-setup_logging()
+from lpm_kernel.configs.logging import get_train_process_logger
 logger = get_train_process_logger()
 
 

--- a/lpm_kernel/file_data/document_service.py
+++ b/lpm_kernel/file_data/document_service.py
@@ -17,8 +17,7 @@ from .embedding_service import EmbeddingService
 from .process_factory import ProcessorFactory
 from .process_status import ProcessStatus
 
-from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
-setup_logging()
+from lpm_kernel.configs.logging import get_train_process_logger
 logger = get_train_process_logger()
 
 

--- a/lpm_kernel/file_data/document_service.py
+++ b/lpm_kernel/file_data/document_service.py
@@ -1,5 +1,4 @@
 # file_data/service.py
-import logging
 from pathlib import Path
 from typing import List, Dict, Optional
 import os
@@ -18,9 +17,9 @@ from .embedding_service import EmbeddingService
 from .process_factory import ProcessorFactory
 from .process_status import ProcessStatus
 
-# from lpm_kernel.file_data.document_dto import DocumentDTO
-
-logger = logging.getLogger(__name__)
+from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
+setup_logging()
+logger = get_train_process_logger()
 
 
 class DocumentService:

--- a/lpm_kernel/file_data/embedding_service.py
+++ b/lpm_kernel/file_data/embedding_service.py
@@ -1,14 +1,14 @@
 from typing import List, Tuple
 import chromadb
 from chromadb.utils import embedding_functions
-import logging
 import os
 from .dto.chunk_dto import ChunkDTO
 from lpm_kernel.common.llm import LLMClient
 from lpm_kernel.file_data.document_dto import DocumentDTO
 from typing import List, Dict, Optional
-
-logger = logging.getLogger(__name__)
+from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
+setup_logging()
+logger = get_train_process_logger()
 
 
 class EmbeddingService:

--- a/lpm_kernel/file_data/embedding_service.py
+++ b/lpm_kernel/file_data/embedding_service.py
@@ -6,8 +6,7 @@ from .dto.chunk_dto import ChunkDTO
 from lpm_kernel.common.llm import LLMClient
 from lpm_kernel.file_data.document_dto import DocumentDTO
 from typing import List, Dict, Optional
-from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
-setup_logging()
+from lpm_kernel.configs.logging import get_train_process_logger
 logger = get_train_process_logger()
 
 

--- a/lpm_kernel/file_data/trainprocess_service.py
+++ b/lpm_kernel/file_data/trainprocess_service.py
@@ -6,7 +6,6 @@ import re
 import time
 import psutil
 from lpm_kernel.configs.config import Config
-from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
 from lpm_kernel.L1.utils import save_true_topics
 from lpm_kernel.L1.serializers import NotesStorage
 from lpm_kernel.kernel.note_service import NoteService
@@ -29,8 +28,7 @@ import threading
 from ..api.domains.trainprocess.progress import TrainProgress, Status, Step, Status
 import gc
 
-from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
-setup_logging()
+from lpm_kernel.configs.logging import get_train_process_logger
 logger = get_train_process_logger()
 
 class ProcessStep(Enum):
@@ -708,7 +706,7 @@ class TrainProcessService:
             # Prepare log directory and file
             log_dir = os.path.join(os.getcwd(), "logs")
             os.makedirs(log_dir, exist_ok=True)
-            log_path = os.path.join(log_dir, "train.log")
+            log_path = os.path.join(log_dir, "train", "train.log")
             self.logger.info(f"Log file path: {log_path}")
             
             # Ensure output directory exists
@@ -730,7 +728,7 @@ class TrainProcessService:
             
             self.logger.info("Training started, monitoring progress")
             # start monitoring training progress
-            return self._monitor_training_progress()
+            return self._monitor_training_progress(log_path)
             
         except Exception as e:
             self.logger.error(f"Failed to start training: {str(e)}")
@@ -809,12 +807,9 @@ class TrainProcessService:
             self.logger.error(f"Failed to start training process: {str(e)}")
             return False
 
-    def _monitor_training_progress(self) -> bool:
+    def _monitor_training_progress(self, log_file) -> bool:
         """Monitor training progress"""
         try:
-            log_dir = os.path.join(os.getcwd(), "logs")
-            log_file = os.path.join(log_dir, "train.log")
-            
             # Initialize last_position to the end of file to only process new content
             try:
                 with open(log_file, 'r') as f:

--- a/lpm_kernel/file_data/trainprocess_service.py
+++ b/lpm_kernel/file_data/trainprocess_service.py
@@ -28,7 +28,7 @@ import threading
 from ..api.domains.trainprocess.progress import TrainProgress, Status, Step, Status
 import gc
 
-from lpm_kernel.configs.logging import get_train_process_logger
+from lpm_kernel.configs.logging import get_train_process_logger, TRAIN_LOG_FILE
 logger = get_train_process_logger()
 
 class ProcessStep(Enum):
@@ -892,8 +892,9 @@ class TrainProcessService:
     def _monitor_model_download(self) -> bool:
         """Monitor model download progress"""
         try:
-            log_dir = os.path.join(os.getcwd(), "logs")
-            log_file = os.path.join(log_dir, "model_download.log")
+            # log_dir = os.path.join(os.getcwd(), "logs")
+            # log_file = os.path.join(log_dir, "model_download.log")
+            log_file = TRAIN_LOG_FILE
             
             # Initialize last_position to the end of file to only process new content
             try:

--- a/lpm_kernel/file_data/trainprocess_service.py
+++ b/lpm_kernel/file_data/trainprocess_service.py
@@ -6,7 +6,7 @@ import re
 import time
 import psutil
 from lpm_kernel.configs.config import Config
-import logging
+from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
 from lpm_kernel.L1.utils import save_true_topics
 from lpm_kernel.L1.serializers import NotesStorage
 from lpm_kernel.kernel.note_service import NoteService
@@ -28,6 +28,10 @@ from lpm_kernel.kernel.l1.l1_manager import generate_l1_from_l0
 import threading
 from ..api.domains.trainprocess.progress import TrainProgress, Status, Step, Status
 import gc
+
+from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
+setup_logging()
+logger = get_train_process_logger()
 
 class ProcessStep(Enum):
     """Training process steps"""
@@ -98,7 +102,7 @@ class Progress:
         self.progress_file = os.path.join(progress_dir, progress_file)
         self.progress = TrainProgress()
         self.progress_callback = progress_callback
-        self.logger = logging.getLogger(__name__)
+        self.logger = logger
         self._load_progress()
 
     def _load_progress(self):
@@ -265,7 +269,7 @@ class TrainProcessService:
             if model_name:
                 progress_file = f"trainprocess_progress_{model_name}.json"
             self.progress = Progress(progress_file, progress_callback)
-            self.logger = logging.getLogger(__name__)
+            self.logger = logger  # 使用训练过程专用日志器
             self.model_name = None  # Initialize as None
             self._initialized = True
             

--- a/lpm_kernel/file_data/trainprocess_service.py
+++ b/lpm_kernel/file_data/trainprocess_service.py
@@ -267,7 +267,7 @@ class TrainProcessService:
             if model_name:
                 progress_file = f"trainprocess_progress_{model_name}.json"
             self.progress = Progress(progress_file, progress_callback)
-            self.logger = logger  # 使用训练过程专用日志器
+            self.logger = logger
             self.model_name = None  # Initialize as None
             self._initialized = True
             

--- a/lpm_kernel/kernel/l1/l1_manager.py
+++ b/lpm_kernel/kernel/l1/l1_manager.py
@@ -16,8 +16,7 @@ from lpm_kernel.models.l1 import (
 )
 from lpm_kernel.models.status_biography import StatusBiography
 
-from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
-setup_logging()
+from lpm_kernel.configs.logging import get_train_process_logger
 logger = get_train_process_logger()
 
 

--- a/lpm_kernel/kernel/l1/l1_manager.py
+++ b/lpm_kernel/kernel/l1/l1_manager.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime
 from typing import List, Optional
 
@@ -17,7 +16,9 @@ from lpm_kernel.models.l1 import (
 )
 from lpm_kernel.models.status_biography import StatusBiography
 
-logger = logging.getLogger(__name__)
+from lpm_kernel.configs.logging import get_train_process_logger, setup_logging
+setup_logging()
+logger = get_train_process_logger()
 
 
 def extract_notes_from_documents(documents) -> tuple[List[Note], list]:

--- a/lpm_kernel/utils.py
+++ b/lpm_kernel/utils.py
@@ -8,7 +8,8 @@ import random
 import string
 from itertools import chain
 import json
-
+from lpm_kernel.configs.logging import get_train_process_logger
+logger = get_train_process_logger()
 
 class IntentType(Enum):
     Emotion = "Emotion"
@@ -187,7 +188,7 @@ class TokenTextSplitter(TextSplitter):
             parts.append(tail)
         res = "\n".join(parts)
 
-        logging.info(
+        logger.info(
             "_cut_meaningless_tail() removes redundant sentence tails from chunks, before cut: %s characters, after cut: %s characters",
             len(text),
             len(res),


### PR DESCRIPTION
The logging configuration is centrally defined in `lpm_kernel/configs/logging.py`, which creates a dedicated logger named `train_process` for training procedures and implements a `rename_existing_log_file()` function. During application startup, this function automatically renames old training logs with timestamp suffixes.

The logging system initialization is implemented in `lpm_kernel/common/logging.py`. 

Training-related scripts like `TrainProcessService` use the `train_process` logger, consolidating all logs into `train/train.log`. Monitoring functions `_monitor_model_download` and `_monitor_training_progress` directly read from this training log file.

The `/logs` API endpoint has been modified to stream logs from `train.log`. Various components now output to this unified log:
- Model download logs are written to `logs/train/train.log`
- `l0_generator.py` logs are directed to `logs/train/train.log`
- `diversity_data_generator.py` tqdm progress logs are captured in `logs/train/train.log`
- `train.py` training-related logs go to `logs/train/train.log`
- `lpm_kernel/utils.py` logs are also routed to `logs/train/train.log`

Additionally, `backend.log` synchronizes with the contents of `logs/train/train.log` to maintain consistency.