### PR TITLE
Fix model download step being skipped during training

### DIFF
--- a/lpm_kernel/file_data/trainprocess_service.py
+++ b/lpm_kernel/file_data/trainprocess_service.py
@@ -705,7 +705,7 @@ class TrainProcessService:
                 download_success = self.model_download()
                 if not download_success:
                     self.logger.error(f"Failed to download model '{self.model_name}'")
-                    self.progress.mark_step_failed(ProcessStep.TRAIN)
+                    self.progress.mark_step_failed(ProcessStep.MODEL_DOWNLOAD)
                     return False
             
             # Prepare log directory and file

--- a/lpm_kernel/file_data/trainprocess_service.py
+++ b/lpm_kernel/file_data/trainprocess_service.py
@@ -697,11 +697,16 @@ class TrainProcessService:
             # Get paths for the model
             paths = self._get_model_paths(self.model_name)
             
-            # Check if model exists
-            if not os.path.exists(paths["base_path"]):
-                self.logger.error(f"Model '{self.model_name}' does not exist, please download first")
-                self.progress.mark_step_failed(ProcessStep.TRAIN)
-                return False
+            # Check if the model directory exists and has the necessary files
+            config_file = os.path.join(paths["base_path"], "config.json")
+            if not os.path.exists(paths["base_path"]) or not os.path.exists(config_file):
+                self.logger.info(f"Model '{self.model_name}' needs to be downloaded or is missing config.json")
+                # Call model_download to download the model
+                download_success = self.model_download()
+                if not download_success:
+                    self.logger.error(f"Failed to download model '{self.model_name}'")
+                    self.progress.mark_step_failed(ProcessStep.TRAIN)
+                    return False
             
             # Prepare log directory and file
             log_dir = os.path.join(os.getcwd(), "logs")


### PR DESCRIPTION

## Issue
The training process skips the model download step when the model directory exists but is missing required files (like `config.json`), causing training to fail later.

## Fix
- Added check for `config.json` file in addition to model directory
- Automatically downloads model if directory or config is missing
- Fixed error handling to use correct ProcessStep enum

## Testing
Verified on Apple M4 Pro with 24GB RAM that:
- Empty model directories trigger download
- Directories missing config.json trigger download
- UI correctly shows download progress

This resolves the issue where users manually place model files in the correct directory but training fails due to missing configuration files.