### PR TITLE
fix: download qwen model to the correct directory

### DIFF
--- a/lpm_kernel/L2/download_model.sh
+++ b/lpm_kernel/L2/download_model.sh
@@ -1,1 +1,1 @@
-python lpm_kernel/L2/utils.py Qwen/Qwen2.5-0.5B-Instruct
+python lpm_kernel/L2/utils.py Qwen2.5-0.5B-Instruct


### PR DESCRIPTION
otherwise the program will raise an error:
```
$ sh -x lpm_kernel/L2/download_model.sh
+ python lpm_kernel/L2/utils.py Qwen/Qwen2.5-0.5B-Instruct
2025-03-26 16:55:56,135 - download_logger - INFO - Starting download of model: Qwen/Qwen2.5-0.5B-Instruct
2025-03-26 16:55:56,135 - download_logger - INFO - Will be saved to: /Users/xyb/projects/second-me/resources/L2/base_models/Qwen/Qwen2.5-0.5B-Instruct
2025-03-26 16:55:56,135 - download_logger - ERROR - Error downloading model: Repo id must be in the form 'repo_name' or 'namespace/repo_name': 'Qwen/Qwen/Qwen2.5-0.5B-Instruct'. Use `repo_type` argument if needed.
Traceback (most recent call last):
  File "/Users/xyb/projects/second-me/lpm_kernel/L2/utils.py", line 555, in <module>
    save_hf_model(sys.argv[1])
  File "/Users/xyb/projects/second-me/lpm_kernel/L2/utils.py", line 392, in save_hf_model
    files = list_repo_files(hf_model_name)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/xyb/miniconda3/envs/second-me/lib/python3.12/site-packages/huggingface_hub/utils/_validators.py", line 106, in _inner_fn
    validate_repo_id(arg_value)
  File "/Users/xyb/miniconda3/envs/second-me/lib/python3.12/site-packages/huggingface_hub/utils/_validators.py", line 154, in validate_repo_id
    raise HFValidationError(
huggingface_hub.errors.HFValidationError: Repo id must be in the form 'repo_name' or 'namespace/repo_name': 'Qwen/Qwen/Qwen2.5-0.5B-Instruct'. Use `repo_type` argument if needed.
```