### PR TITLE
fix: Replace file path handling with pathlib to resolve f-string syntax error

### DIFF
--- a/lpm_kernel/api/file_server/handler.py
+++ b/lpm_kernel/api/file_server/handler.py
@@ -57,13 +57,14 @@ class FileServerHandler:
         for item in os.scandir(target_dir):
             item_type = "directory" if item.is_dir() else "file"
             item_size = os.path.getsize(item.path) if item.is_file() else None
+            file_path = (Path(path) / item.name).as_posix()
             items.append(
                 FileItem(
                     name=item.name,
                     type=item_type,
                     size=item_size,
-                    path=os.path.join(path, item.name).replace("\\", "/"),
-                    url=f"/raw_content/{os.path.join(path, item.name).replace('\\', '/')}"
+                    path=file_path,
+                    url=f"/raw_content/{file_path}"
                     if item.is_file()
                     else None,
                 )


### PR DESCRIPTION
When I uploaded the file yesterday and restarted the project today, I encountered this error.

# Issue

A syntax error occurs when running `make start` command due to backslashes in f-string expressions, resulting in application startup failure. The error message shows:
```
Traceback (most recent call last):
  ... ...
  File "/Users/.../Second-Me/lpm_kernel/api/file_server/handler.py", line 67
    if item.is_file()
    ^^
SyntaxError: f-string expression part cannot include a backslash
```

# Simple description
- Fix f-string syntax error caused by backslashes
- Use Path().as_posix() for consistent path formatting

# Cause analysis
1. The original code used a combination of `os.path.join()` and `replace()` for path handling:
```python
path=os.path.join(path, item.name).replace("\\", "/"),
url=f"/raw_content/{os.path.join(path, item.name).replace('\\', '/')}"
```

2. The problem lies in the f-string:
- Python's f-string syntax doesn't allow backslashes in expression parts
- `replace('\\', '/')` in f-string is interpreted as escape characters, causing syntax error
- This path handling approach may produce inconsistent results across different operating systems（Although only MacOS is currently supported LOL）

# Fix
Implemented path handling using Python's `pathlib.Path` class:
```python
file_path = (Path(path) / item.name).as_posix()
path=file_path,
url=f"/raw_content/{file_path}"
```

# Improvements
1. More Concise Code:
   - Uses Path class's `/` operator instead of `os.path.join()`
   - `as_posix()` method handles path separators automatically, eliminating manual replacement

2. More Reliable:
   - Avoids escape character issues in f-strings
   - `Path` class provides cross-platform path handling capabilities
   - Reduces string operations, lowering the risk of errors

# Testing
Verified functionality in the following scenarios:
- `make start` command executes without syntax errors
- File paths are consistently formatted with forward slashes (/)
- Directory listing functionality works as expected
