### PR TITLE
Fix: Ensure env_file is a Path

### DIFF
--- a/lpm_kernel/configs/config.py
+++ b/lpm_kernel/configs/config.py
@@ -53,9 +53,7 @@ class Config:
             return cls._instance
 
         # Load .env file
-        env_path = (
-            env_file if env_file else Path(__file__).parent.parent.parent / ".env"
-        )
+        env_path = Path(env_file) if env_file else Path(__file__).parent.parent.parent / ".env"
 
         if env_path.exists():
             load_dotenv(env_path)


### PR DESCRIPTION
# Problem Description
When a string-type `env_file` parameter is passed into the `from_env` method, it causes an error because strings do not have an `exists()` method.

# Solution
Convert the incoming `env_file` parameter to a `Path` object, regardless of whether it is a string or already a Path object.

# Tests
The following scenarios have been tested:

Not passing the env_file parameter
Passing a string-type env_file
Passing a Path object-type env_file