### PR TITLE
fix: add m1 homebrew conda.sh path

### DIFF
--- a/scripts/conda_utils.sh
+++ b/scripts/conda_utils.sh
@@ -73,6 +73,7 @@ find_and_source_conda_sh() {
         "$HOME/anaconda/etc/profile.d/conda.sh"
         "$HOME/opt/anaconda3/etc/profile.d/conda.sh"
         "$HOME/opt/miniconda3/etc/profile.d/conda.sh"
+        "/opt/homebrew/anaconda3/etc/profile.d/conda.sh"
         "/opt/homebrew/Caskroom/miniconda/base/etc/profile.d/conda.sh"
         "/opt/anaconda3/etc/profile.d/conda.sh"
         "/opt/miniconda3/etc/profile.d/conda.sh"


### PR DESCRIPTION
When installing Anaconda on an M1 Mac using `brew install --cask anaconda`, encounter an error stating that conda.sh cannot be found when running `make start`. 

This PR adds the default Homebrew installation path for conda.sh on Apple Silicon (M1) Macs to the detection list.