### PR TITLE
fix: copy to clipboard

### DIFF
--- a/lpm_frontend/src/components/roleplay/RoleCard.tsx
+++ b/lpm_frontend/src/components/roleplay/RoleCard.tsx
@@ -5,6 +5,7 @@ import type { RoleRes, UpdateRoleReq } from '@/service/role';
 import { Modal, message } from 'antd';
 import { MoreOutlined } from '@ant-design/icons';
 import { useLoadInfoStore } from '@/store/useLoadInfoStore';
+import { copyToClipboard } from '@/utils/copy';
 
 interface RoleCardProps {
   role: RoleRes;
@@ -289,16 +290,17 @@ export default function RoleCard({ role, onClick, onEdit, onDelete }: RoleCardPr
             <button
               className="w-full px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
               onClick={async () => {
-                try {
-                  await navigator.clipboard.writeText('https://secondme.ai/share/123456');
-                  messageApi.success({
-                    content: 'Link copied to clipboard'
+                copyToClipboard('https://secondme.ai/share/123456')
+                  .then(() => {
+                    messageApi.success({
+                      content: 'Link copied.'
+                    });
+                  })
+                  .catch(() => {
+                    messageApi.error({
+                      content: 'Failed to copy, please copy manually'
+                    });
                   });
-                } catch (error: any) {
-                  messageApi.error({
-                    content: error.message || 'Failed to copy, please copy manually'
-                  });
-                }
               }}
             >
               Copy Link

--- a/lpm_frontend/src/components/roleplay/ShareRoleModal.tsx
+++ b/lpm_frontend/src/components/roleplay/ShareRoleModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useLoadInfoStore } from '@/store/useLoadInfoStore';
+import { copyToClipboard } from '@/utils/copy';
 import { Modal, message } from 'antd';
 import { useEffect, useState } from 'react';
 
@@ -29,16 +30,17 @@ export default function ShareRoleModal({ open, onClose, uuid, isRegistered }: Sh
   }, [isRegistered, uuid, loadInfo]);
 
   const handleCopyLink = async () => {
-    try {
-      await navigator.clipboard.writeText(shareUrl);
-      message.success({
-        content: 'Link copied to clipboard'
+    copyToClipboard(shareUrl)
+      .then(() => {
+        message.success({
+          content: 'Link copied.'
+        });
+      })
+      .catch(() => {
+        message.error({
+          content: 'Copy failed, please copy manually.'
+        });
       });
-    } catch (error: any) {
-      message.error({
-        content: error.message || 'Copy failed, please copy manually'
-      });
-    }
   };
 
   return (

--- a/lpm_frontend/src/components/spaces/ShareSpaceModal.tsx
+++ b/lpm_frontend/src/components/spaces/ShareSpaceModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { copyToClipboard } from '@/utils/copy';
 import { Modal, message } from 'antd';
 import { useEffect, useState } from 'react';
 
@@ -31,16 +32,17 @@ export default function ShareSpaceModal({
   }, [isRegistered, space_id]);
 
   const handleCopyLink = async () => {
-    try {
-      await navigator.clipboard.writeText(shareUrl);
-      messageApi.success({
-        content: 'Link copied to clipboard'
+    copyToClipboard(shareUrl)
+      .then(() => {
+        messageApi.success({
+          content: 'Link copied.'
+        });
+      })
+      .catch(() => {
+        messageApi.error({
+          content: 'Copy failed, please copy manually.'
+        });
       });
-    } catch (error: any) {
-      messageApi.error({
-        content: error.message || 'Copy failed, please copy manually'
-      });
-    }
   };
 
   return (

--- a/lpm_frontend/src/components/upload/RegisterUploadModal.tsx
+++ b/lpm_frontend/src/components/upload/RegisterUploadModal.tsx
@@ -19,6 +19,7 @@ import { updateRegisteredUpload } from '@/utils/localRegisteredUpload';
 import NetWorkMemberList from './NetWorkMemberList';
 import { useLoadInfoStore } from '@/store/useLoadInfoStore';
 import { getCurrentInfo } from '@/service/info';
+import { copyToClipboard } from '@/utils/copy';
 
 interface RegisterUploadModalProps {
   open: boolean;
@@ -237,10 +238,15 @@ export default function RegisterUploadModal({ open, onClose }: RegisterUploadMod
           <button
             className="absolute top-1/2 -translate-y-1/2 right-2 p-1.5 bg-indigo-100 text-indigo-600 rounded-md hover:bg-indigo-200 transition-colors"
             onClick={() => {
-              navigator.clipboard.writeText(
+              copyToClipboard(
                 `https://app.secondme.io/${currentUpload.upload_name}/${currentUpload.instance_id}`
-              );
-              message.success('Copied to clipboard');
+              )
+                .then(() => {
+                  message.success('Copied.');
+                })
+                .catch(() => {
+                  message.error('Copy failed, please copy manually.');
+                });
             }}
           >
             <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -262,10 +268,15 @@ export default function RegisterUploadModal({ open, onClose }: RegisterUploadMod
           <button
             className="absolute top-1/2 -translate-y-1/2 right-2 p-1.5 bg-indigo-100 text-indigo-600 rounded-md hover:bg-indigo-200 transition-colors"
             onClick={() => {
-              navigator.clipboard.writeText(
+              copyToClipboard(
                 `https://app.secondme.io/api/chat/${currentUpload.instance_id}/chat/completions`
-              );
-              message.success('Copied to clipboard');
+              )
+                .then(() => {
+                  message.success('Copied.');
+                })
+                .catch(() => {
+                  message.error('Copy failed, please copy manually.');
+                });
             }}
           >
             <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/lpm_frontend/src/utils/copy.ts
+++ b/lpm_frontend/src/utils/copy.ts
@@ -1,0 +1,48 @@
+const manualCopyFallback = (textToCopy: string): void => {
+  const textArea = document.createElement('textarea');
+
+  textArea.value = textToCopy;
+
+  textArea.style.position = 'absolute';
+  textArea.style.left = '-999999px';
+
+  document.body.prepend(textArea);
+  textArea.select();
+
+  try {
+    document.execCommand('copy');
+  } catch (error) {
+    console.error(error);
+  } finally {
+    textArea.remove();
+  }
+};
+
+export const copyToClipboard = (textToCopy: string) => {
+  return new Promise<void>((resolve, reject) => {
+    if (navigator.clipboard && window.isSecureContext) {
+      setTimeout(() => {
+        navigator.clipboard
+          .writeText(textToCopy)
+          .then(() => {
+            resolve();
+          })
+          .catch(() => {
+            try {
+              manualCopyFallback(textToCopy);
+              resolve();
+            } catch (manualError) {
+              reject(manualError);
+            }
+          });
+      });
+    } else {
+      try {
+        manualCopyFallback(textToCopy);
+        resolve();
+      } catch {
+        reject();
+      }
+    }
+  });
+};


### PR DESCRIPTION
This PR introduces a new clipboard copy method that gracefully handles cases where navigator.clipboard is unavailable or not supported.

Changes include:
- Adding a new function `copyToClipboard` that attempts to use the modern clipboard API when available in a secure context.
- Falling back to a manual copy approach using a temporary textarea (`manualCopyFallback`) if the clipboard API fails or is unsupported.

This enhancement prevents errors when copying to the clipboard in unsupported environments and improves overall robustness.