### PR TITLE
fix: implement dynamic top_p parameter adjustment for LLM API calls

### DIFF
--- a/lpm_kernel/L1/shade_generator.py
+++ b/lpm_kernel/L1/shade_generator.py
@@ -53,7 +53,71 @@ class ShadeGenerator:
                 base_url=self.user_llm_config.chat_endpoint,
             )
             self.model_name = self.user_llm_config.chat_model_name
+        self._top_p_adjusted = False  # Flag to track if top_p has been adjusted
 
+    def _fix_top_p_param(self, error_message: str) -> bool:
+        """Fixes the top_p parameter if an API error indicates it's invalid.
+        
+        Some LLM providers don't accept top_p=0 and require values in specific ranges.
+        This function checks if the error is related to top_p and adjusts it to 0.001,
+        which is close enough to 0 to maintain deterministic behavior while satisfying
+        API requirements.
+        
+        Args:
+            error_message: Error message from the API response.
+            
+        Returns:
+            bool: True if top_p was adjusted, False otherwise.
+        """
+        if not self._top_p_adjusted and "top_p" in error_message.lower():
+            logger.warning("Fixing top_p parameter from 0 to 0.001 to comply with model API requirements")
+            self.model_params["top_p"] = 0.001
+            self._top_p_adjusted = True
+            return True
+        return False
+
+    def _call_llm_with_retry(self, messages: List[Dict[str, str]], **kwargs) -> Any:
+        """Calls the LLM API with automatic retry for parameter adjustments.
+        
+        This function handles making API calls to the language model while
+        implementing automatic parameter fixes when errors occur. If the API
+        rejects the call due to invalid top_p parameter, it will adjust the
+        parameter value and retry the call once.
+        
+        Args:
+            messages: List of messages for the API call.
+            **kwargs: Additional parameters to pass to the API call.
+            
+        Returns:
+            API response object from the language model.
+            
+        Raises:
+            Exception: If the API call fails after all retries or for unrelated errors.
+        """
+        try:
+            return self.client.chat.completions.create(
+                model=self.model_name,
+                messages=messages,
+                **self.model_params,
+                **kwargs
+            )
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(f"API Error: {error_msg}")
+            
+            # Try to fix top_p parameter if needed
+            if hasattr(e, 'response') and hasattr(e.response, 'status_code') and e.response.status_code == 400:
+                if self._fix_top_p_param(error_msg):
+                    logger.info("Retrying LLM API call with adjusted top_p parameter")
+                    return self.client.chat.completions.create(
+                        model=self.model_name,
+                        messages=messages,
+                        **self.model_params,
+                        **kwargs
+                    )
+            
+            # Re-raise the exception
+            raise
 
     def _build_message(self, system_prompt: str, user_prompt: str) -> List[Dict[str, str]]:
         """Builds the message structure for the LLM API.
@@ -101,11 +165,7 @@ Domain Timelines:
         shift_perspective_message = self._build_message(
             PERSON_PERSPECTIVE_SHIFT_V2_PROMPT, user_prompt
         )
-        response = self.client.chat.completions.create(
-            model=self.model_name,
-            messages=shift_perspective_message,
-            **self.model_params,
-        )
+        response = self._call_llm_with_retry(shift_perspective_message)
         content = response.choices[0].message.content
         shift_pattern = r"\{.*\}"
         shift_perspective_result = self.__parse_json_response(content, shift_pattern)
@@ -184,9 +244,7 @@ Domain Timelines:
 
         shade_generate_message = self._build_message(SHADE_INITIAL_PROMPT, user_prompt)
 
-        response = self.client.chat.completions.create(
-            model=self.model_name, messages=shade_generate_message, **self.model_params
-        )
+        response = self._call_llm_with_retry(shade_generate_message)
         content = response.choices[0].message.content
 
         logger.info(f"Shade Generate Result: {content}")
@@ -213,9 +271,7 @@ Domain Timelines:
         )
 
         merge_shades_message = self._build_message(SHADE_MERGE_PROMPT, user_prompt)
-        response = self.client.chat.completions.create(
-            model=self.model_name, messages=merge_shades_message, **self.model_params
-        )
+        response = self._call_llm_with_retry(merge_shades_message)
         content = response.choices[0].message.content
         logger.info(f"Shade Generate Result: {content}")
         return self.__shade_merge_postprocess(content)
@@ -302,9 +358,7 @@ Recent Memories:
 {recent_memories_str}
 """
         shade_improve_message = self._build_message(SHADE_IMPROVE_PROMPT, user_prompt)
-        response = self.client.chat.completions.create(
-            model=self.model_name, messages=shade_improve_message, **self.model_params
-        )
+        response = self._call_llm_with_retry(shade_improve_message)
         content = response.choices[0].message.content
         logger.info(f"Shade Generate Result: {content}")
         return self.__shade_improve_postprocess(old_shade_info, content)
@@ -525,11 +579,7 @@ class ShadeMerger:
             )
             logger.info(f"Built merge_decision_message: {merge_decision_message}")
 
-            response = self.client.chat.completions.create(
-                model=self.model_name,
-                messages=merge_decision_message,
-                **self.model_params,
-            )
+            response = self._call_llm_with_retry(merge_decision_message)
             content = response.choices[0].message.content
             logger.info(f"Shade Merge Decision Result: {content}")
 

--- a/lpm_kernel/L1/status_bio_generator.py
+++ b/lpm_kernel/L1/status_bio_generator.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Any
 import logging
 
 from openai import OpenAI
@@ -8,6 +8,9 @@ from lpm_kernel.L1.prompt import PREFER_LANGUAGE_SYSTEM_PROMPT, STATUS_BIO_SYSTE
 from lpm_kernel.L1.utils import get_cur_time, is_valid_chat, is_valid_note, is_valid_todo
 from lpm_kernel.api.services.user_llm_config_service import UserLLMConfigService
 from lpm_kernel.configs.config import Config
+from lpm_kernel.configs.logging import get_train_process_logger
+
+logger = get_train_process_logger()
 
 
 class StatusBioGenerator:
@@ -33,7 +36,71 @@ class StatusBioGenerator:
                 timeout=45.0,  # Set global timeout
             )
             self.model_name = self.user_llm_config.chat_model_name
+        self._top_p_adjusted = False  # Flag to track if top_p has been adjusted
 
+    def _fix_top_p_param(self, error_message: str) -> bool:
+        """Fixes the top_p parameter if an API error indicates it's invalid.
+        
+        Some LLM providers don't accept top_p=0 and require values in specific ranges.
+        This function checks if the error is related to top_p and adjusts it to 0.001,
+        which is close enough to 0 to maintain deterministic behavior while satisfying
+        API requirements.
+        
+        Args:
+            error_message: Error message from the API response.
+            
+        Returns:
+            bool: True if top_p was adjusted, False otherwise.
+        """
+        if not self._top_p_adjusted and "top_p" in error_message.lower():
+            logger.warning("Fixing top_p parameter from 0 to 0.001 to comply with model API requirements")
+            self.model_params["top_p"] = 0.001
+            self._top_p_adjusted = True
+            return True
+        return False
+
+    def _call_llm_with_retry(self, messages: List[Dict[str, str]], **kwargs) -> Any:
+        """Calls the LLM API with automatic retry for parameter adjustments.
+        
+        This function handles making API calls to the language model while
+        implementing automatic parameter fixes when errors occur. If the API
+        rejects the call due to invalid top_p parameter, it will adjust the
+        parameter value and retry the call once.
+        
+        Args:
+            messages: List of messages for the API call.
+            **kwargs: Additional parameters to pass to the API call.
+            
+        Returns:
+            API response object from the language model.
+            
+        Raises:
+            Exception: If the API call fails after all retries or for unrelated errors.
+        """
+        try:
+            return self.client.chat.completions.create(
+                model=self.model_name,
+                messages=messages,
+                **self.model_params,
+                **kwargs
+            )
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(f"API Error: {error_msg}")
+            
+            # Try to fix top_p parameter if needed
+            if hasattr(e, 'response') and hasattr(e.response, 'status_code') and e.response.status_code == 400:
+                if self._fix_top_p_param(error_msg):
+                    logger.info("Retrying LLM API call with adjusted top_p parameter")
+                    return self.client.chat.completions.create(
+                        model=self.model_name,
+                        messages=messages,
+                        **self.model_params,
+                        **kwargs
+                    )
+            
+            # Re-raise the exception
+            raise
 
     def _build_message(self, user_info: UserInfo, language: str) -> List[Dict[str, str]]:
         """Build message list for generating status biography.
@@ -78,11 +145,9 @@ class StatusBioGenerator:
         user_info = UserInfo(cur_time, notes, todos, chats)
         messages = self._build_message(user_info, self.preferred_language)
 
-        answer = self.client.chat.completions.create(
-            model=self.model_name, messages=messages, **self.model_params
-        )
+        answer = self._call_llm_with_retry(messages)
         content = answer.choices[0].message.content
-        logging.info(f"Generated content: {content}")
+        logger.info(f"Generated content: {content}")
 
         # Create and return Bio object, ensuring all content fields have values
         return Bio(


### PR DESCRIPTION
- Add _top_p_adjusted flag to track parameter adjustments
- Implement _fix_top_p_param to adjust invalid top_p values
- Enhance _call_llm_with_retry with parameter adjustment retry mechanism
- Apply consistent implementation across all generator classes
- Improve error logging for API error debugging

---

# Issue

When I request LLM API with `top_p=0`, some model providers （such as DeepSeek）reject the request with a 400 error, indicating that the valid range for `top_p` is (0, 1.0]. This causes API calls to fail in various generators(L1), including `L1Generator`, `TopicsGenerator`, `ShadeGenerator`, and `StatusBioGenerator`.

# Cause analysis
1. The original code had these issues:
```python
# In all generator classes - hardcoded top_p=0
self.model_params = {
    "temperature": 0,
    "top_p": 0,  # This value is rejected by some LLM providers
    # other parameters...
}

# No error handling for invalid top_p parameter
```

2. The problems with this approach:
- Compatibility issues: Different LLM providers have different requirements for valid parameter ranges
- Rigid configuration: No flexibility to adjust parameters when API calls fail
- Poor error handling: API errors related to parameter validation were not properly handled
- No retry mechanism: Failed API calls were not retried with adjusted parameters

# Fix
1. Implemented a flag to track parameter adjustments:
```python
self._top_p_adjusted = False  # Flag to track if top_p has been adjusted
```

2. Added a function to fix top_p parameter when errors occur:
```python
def _fix_top_p_param(self, error_message: str) -> bool:
    if not self._top_p_adjusted and "top_p" in error_message.lower():
        logger.warning(f"API Error: {error_message}")
        logger.info("Fixing top_p parameter from 0 to 0.001 to comply with model API requirements")
        self.bio_model_params["top_p"] = 0.001
        self._top_p_adjusted = True
        return True
    return False
```

3. Enhanced the API call method with retry mechanism:
```python
def _call_llm_with_retry(self, messages: List[Dict[str, str]], **kwargs) -> Any:
    try:
        return self.client.chat.completions.create(
            model=self.model_name,
            messages=messages,
            **self.bio_model_params,
            **kwargs
        )
    except Exception as e:
        error_msg = str(e)
        logger.error(f"API Error: {error_msg}")
        
        # Try to fix top_p parameter if needed
        if hasattr(e, 'response') and hasattr(e.response, 'status_code') and e.response.status_code == 400:
            if self._fix_top_p_param(error_msg):
                logger.info("Retrying LLM API call with adjusted top_p parameter")
                return self.client.chat.completions.create(
                    model=self.model_name,
                    messages=messages,
                    **self.bio_model_params,
                    **kwargs
                )
        
        # Re-raise the exception
        raise
```

Currently, only the `top_p` parameter for error handling and dynamic adjustment. I think: If other parameter error issues arise in the future, error handling can be added on this basis.

4. Applied these changes consistently across all four generator classes:
   - `L1Generator`
   - `TopicsGenerator`
   - `ShadeGenerator`
   - `StatusBioGenerator`

Each generator has implemented the same logic, which may be a bit redundant, but in order not to compromise the independence of each generator, I think I should do it this way.

# Improvements
1. Increased Compatibility:
   - System now works with LLM providers that don't accept top_p=0
   - Uses a value close to 0 (0.001) to maintain near-deterministic behavior

2. Robust Error Handling:
   - Properly logs API errors for debugging
   - Provides clear information about parameter adjustments

3. Automatic Recovery:
   - Implements a retry mechanism to recover from parameter validation errors

4. Consistent Implementation:
   - Same fix applied uniformly across all (L1) generators
   - Maintains code consistency throughout the codebase

# Share my thinking

At first, I wanted to simply add a configuration item in `.env` to uniformly set `top_p` and `temperature`, but after reviewing the code of the generator, I realized that there may be different parameter sets for each individual generator in the future development of the project. Therefore, it is not necessary to unify the parameter configuration here. 

In addition, considering the concept of the project, I believe that the generated results should be as close to the data itself as possible. Therefore, it is not necessary to treat it as a customized configuration item here. I only need to dynamically update `top_p` to a value as close to 0 as possible, which will achieve a very close approximation; and `temperature` is a value that almost all mainstream models support setting to `0`, so I will not make dynamic adjustments to it for now.