### PR TITLE
fix: support for non-OpenAI embedding model in graphrag_indexing()

### DIFF
--- a/lpm_kernel/L2/data.py
+++ b/lpm_kernel/L2/data.py
@@ -527,11 +527,11 @@ class L2DataProcessor:
 
         if chat_model_name.startswith("openai"):
             settings["models"]["default_chat_model"]["model"] = chat_model_name.replace("openai/", "")
-        else:
-            settings["models"]["default_chat_model"]["model"] = chat_model_name
 
         if embedding_model_name.startswith("openai"):
             settings["models"]["default_embedding_model"]["model"] = embedding_model_name.replace("openai/", "")
+        else:
+            settings["models"]["default_embedding_model"]["model"] = embedding_model_name
 
         settings["models"]["default_embedding_model"]["api_base"] = embedding_base_url
         settings["models"]["default_embedding_model"]["api_key"] = embedding_api_key

--- a/lpm_kernel/L2/data.py
+++ b/lpm_kernel/L2/data.py
@@ -527,6 +527,8 @@ class L2DataProcessor:
 
         if chat_model_name.startswith("openai"):
             settings["models"]["default_chat_model"]["model"] = chat_model_name.replace("openai/", "")
+        else:
+            settings["models"]["default_chat_model"]["model"] = chat_model_name
 
         if embedding_model_name.startswith("openai"):
             settings["models"]["default_embedding_model"]["model"] = embedding_model_name.replace("openai/", "")


### PR DESCRIPTION
The original code only processed embedding model names starting with "openai/", leaving other model names unhandled. This change adds an else branch to ensure non-OpenAI embedding model names are also correctly set in the configuration. This PR specifically addresses the issue where encounter non-OpenAI embedding model handling during graphrag_indexing would cause the program to hang.

Changes:

- Added an else clause to the if embedding_name.startswith("openai") condition
    
- For non-OpenAI embedding model names, the raw name is now directly assigned
    
- Fixed the program hanging issue during graphrag_indexing when  embedding model is not properly set