### PR TITLE
fix: Invalid progress file path on Windows

### DIFF
--- a/lpm_kernel/file_data/trainprocess_service.py
+++ b/lpm_kernel/file_data/trainprocess_service.py
@@ -78,7 +78,7 @@ class Progress:
     def __init__(
         self, progress_file: str = "trainprocess_progress.json", progress_callback=None
     ):
-        progress_dir = os.path.join(os.getcwd(), "data/progress")
+        progress_dir = os.path.join(os.getcwd(), "data", "progress")
         if not os.path.exists(progress_dir):
             os.makedirs(progress_dir)
         self.progress_file = os.path.normpath(os.path.join(progress_dir, progress_file))


### PR DESCRIPTION
On Windows, path separator is "\\" instead of "/" on Linux/macOS.

Before the fix, `os.path.join(os.getcwd(), "data/progress")` just adds a line separator, and left "data/progress" untouched.

But after `os.path.normpath`, the "/" gets transformed into "\\" on Windows, therefore failing the check:
https://github.com/mindverse/Second-Me/blob/ff61385ac606d7384c6e5c3c5ab7cba70acf8435/lpm_kernel/file_data/trainprocess_service.py#L85

This PR fixes the problem by feeding "data" and "progress" separately, then Python will treat them using platform-specific separators.

Tested locally and it works on Windows 11, Python 3.12.4.