### PR TITLE
fix: hotfix for missing encoding_model_name in setting.yaml(GraphRAG)

### DIFF
--- a/lpm_kernel/L2/data_pipeline/graphrag_indexing/settings.yaml
+++ b/lpm_kernel/L2/data_pipeline/graphrag_indexing/settings.yaml
@@ -52,6 +52,7 @@ models:
     retry_strategy: native
     tokens_per_minute: 0
     type: openai_embedding
+    encoding_model: cl100k_base
 output:
   base_dir: /your_dir
   type: file


### PR DESCRIPTION
Added encoding_model to default_embedding_model in settings.yaml

**Changes:**
- Added encoding_model configuration to the default_embedding_model section in settings.yaml
- This change prevents encoding errors during the GraphRAG process by explicitly specifying the encoding model to be used