### PR TITLE
fix: Wrong encoding on reading backend.log

### DIFF
--- a/lpm_kernel/api/domains/trainprocess/routes.py
+++ b/lpm_kernel/api/domains/trainprocess/routes.py
@@ -3,6 +3,7 @@ import time
 from pathlib import Path
 from werkzeug.utils import secure_filename
 from flask import Blueprint, jsonify, Response, request
+from charset_normalizer import from_path
 
 from lpm_kernel.file_data.trainprocess_service import TrainProcessService
 from .progress import Status
@@ -88,7 +89,8 @@ def stream_logs():
         nonlocal last_position
         while True:
             try:
-                with open(log_file_path, 'r') as log_file:
+                encoding = from_path(log_file_path).best().encoding
+                with open(log_file_path, 'r', encoding=encoding) as log_file:
                     log_file.seek(last_position)
                     new_lines = log_file.readlines()  # Read new lines
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ sentencepiece = "^0.2.0"
 httpx = {extras = ["socks"], version = "^0.28.1"}
 python-socks = "^2.4.0"
 jsonlines = "^4.0.0"
+charset-normalizer = "^3.4.1"
 
 # Development environment dependencies
 # Use 'poetry install --with dev' to install development dependencies


### PR DESCRIPTION
Fixes #170 by determining the encoding prior to read.

Tested successfully on Windows 11, and further testing on other environments might be necessary.

Note: This PR **adds a new dependency**, I am not sure if this is acceptable, as it may need people to rerun **poetry install** on upgrade. 