### PR TITLE
fix: incorrect script paths in `stop.sh` and `start.sh`

### DIFF
--- a/scripts/restart-force.sh
+++ b/scripts/restart-force.sh
@@ -10,7 +10,7 @@ restart_services_force() {
     
     # Stop services
     log_info "Stopping services..."
-    ./scripts/stop.sh
+    "${SCRIPT_DIR}/scripts/stop.sh"
     
     # Remove data directory
     log_warning "Removing data directory..."
@@ -18,7 +18,7 @@ restart_services_force() {
 
     # Start services
     log_info "Starting services..."
-    ./scripts/start.sh
+    "${SCRIPT_DIR}/scripts/start.sh"
 }
 
 # Execute force restart services


### PR DESCRIPTION
i noticed an issue with the paths to the `stop.sh` and `start.sh` scripts. they were relative paths, which could break if the script is run from a different directory.

i've updated the paths to use the `${SCRIPT_DIR}` variable, which ensures the correct absolute path is used, regardless of the current working directory.

this should prevent any errors related to incorrect paths when invoking the scripts.