### PR TITLE
fix: fix multi-upload

### DIFF
--- a/lpm_kernel/api/domains/loads/load_service.py
+++ b/lpm_kernel/api/domains/loads/load_service.py
@@ -28,14 +28,13 @@ class LoadService:
         """
         try:
             with DatabaseSession.session() as session:
-                # Check if there are multiple loads
+                # Check if there are any loads
                 load_count = session.query(Load).count()
-                if load_count > 1:
-                    return None, "Multiple load records exist in the system, please clean up first", 400
-                
-                current_load = session.query(Load).first()
-                if not current_load:
+                if load_count == 0:
                     return None, "Load record not found", 404
+                
+                # Get the most recently created load
+                current_load = session.query(Load).order_by(Load.created_at.desc()).first()
                 
                 return LoadDTO.from_model(current_load, with_password), None, 200
         except Exception as e:


### PR DESCRIPTION

# Problem Description

When multiple Load records exist in the system, the get_current_load method returns an error message "Multiple load records exist in the system, please clean up first" with a 400 status code, causing the API call to fail. This situation may occur when users create multiple Load records, affecting normal system usage.

# Steps to Reproduce

- Create one Load record in the system
- Create another Load record without deleting the existing one
- Call the /api/loads/current API endpoint
- Observe that the API returns a 400 error with the message "Multiple load records exist in the system, please clean up first"

# Current Impact
- The system requires users to manually clean up the database, which is difficult for regular users
- API call failures prevent dependent features from working properly
- Negative impact on user experience

# Fix Solution
Optimize the get_current_load method to handle multiple Load records:

Remove the error response when multiple records are detected
Instead, return the most recently created record based on the created_at field
Maintain the same response format for API consistency

# Benefits of the Fix
- Improved system resilience by handling edge cases gracefully
- Better user experience as the system continues to function normally
- Reduced need for technical intervention
- Simplified code with a more consistent query approach

# Implementation Details
The updated method now uses order_by(Load.created_at.desc()).first() to retrieve the most recently created Load record, regardless of how many records exist in the database.