### PR TITLE
Feature/fix update instace

### DIFF
--- a/lpm_kernel/api/domains/loads/load_service.py
+++ b/lpm_kernel/api/domains/loads/load_service.py
@@ -60,10 +60,10 @@ class LoadService:
         """
         try:
             with DatabaseSession.session() as session:
-                # Check if a load record with the same name exists
-                existing_load = session.query(Load).filter(Load.name == name).first()
+                # Check if any load record exists
+                existing_load = session.query(Load).first()
                 if existing_load:
-                    return None, f"A load record with name '{name}' already exists", 400
+                    return None, f"A load record already exists. Only one load record is allowed in the system.", 400
                 
                 # Create a new Load instance
                 new_load = Load(
@@ -106,13 +106,9 @@ class LoadService:
                     return None, "Load record not found", 404
                 
                 # Update fields
-                updatable_fields = ["name", "description", "email", "avatar_data", "instance_id", "status"]
+                updatable_fields = ["name", "description", "email", "avatar_data"]
                 for field in updatable_fields:
                     if field in data:
-                        # Special validation for status field
-                        if field == "status" and data[field] not in ["active", "inactive", "deleted"]:
-                            return None, f"Status must be one of 'active', 'inactive', or 'deleted'", 400
-                        
                         setattr(load, field, data[field])
                 
                 session.commit()
@@ -144,7 +140,7 @@ class LoadService:
         return LoadService.update_load(current_load.id, data)
     
     @staticmethod
-    def update_instance_id(instance_id: str, instance_password: str = None) -> Tuple[bool, Optional[str], int]:
+    def update_instance_credentials(instance_id: str, instance_password: str) -> Tuple[bool, Optional[str], int]:
         """
         Update the instance_id and instance_password of the current load
         
@@ -158,22 +154,34 @@ class LoadService:
             - Error message or None if successful
             - Status code (200 for success, 400/404/500 for errors)
         """
-        try:
-            logger.info(f"Updating instance_id to {instance_id} and instance_password to {instance_password}")
+        try:            
+            logger.info(f"Updating instance credentials: ID={instance_id}, Password={'*****' if instance_password else None}")
+
+            # Get current load
+            current_load, error, status_code = LoadService.get_current_load()
+            if error:
+                return False, error, status_code
+            
+            if not current_load:
+                logger.warning("Load record not found")
+                return False, "Load record not found", 404
+            
+            # Update fields in database
             with DatabaseSession.session() as session:
-                load = session.query(Load).first()
+                load = session.query(Load).get(current_load["id"])
                 if not load:
-                    logger.warning("Load record not found")
-                    return False, "Load record not found", 404
+                    logger.warning("Load record not found in database")
+                    return False, "Load record not found in database", 404
                 
                 load.instance_id = instance_id
-                if instance_password:
-                    load.instance_password = instance_password
+                load.instance_password = instance_password
+                
                 session.commit()
-                logger.info(f"Updated instance_id in database to: {instance_id}, instance_password: {instance_password}")
+                
+                logger.info(f"Updated instance credentials successfully")
                 return True, None, 200
         except Exception as e:
-            logger.error(f"Error updating instance_id: {str(e)}", exc_info=True)
+            logger.error(f"Error updating instance credentials: {str(e)}", exc_info=True)
             return False, f"Internal server error: {str(e)}", 500
     
     @staticmethod

--- a/lpm_kernel/api/domains/loads/load_service.py
+++ b/lpm_kernel/api/domains/loads/load_service.py
@@ -168,7 +168,7 @@ class LoadService:
             
             # Update fields in database
             with DatabaseSession.session() as session:
-                load = session.query(Load).get(current_load["id"])
+                load = session.query(Load).get(current_load.id)
                 if not load:
                     logger.warning("Load record not found in database")
                     return False, "Load record not found in database", 404

--- a/lpm_kernel/api/domains/upload/routes.py
+++ b/lpm_kernel/api/domains/upload/routes.py
@@ -39,7 +39,7 @@ def register_upload():
             ))
         
         instance_password = result.get("instance_password")
-        LoadService.update_instance_id(instance_id_new, instance_password)
+        LoadService.update_instance_credentials(instance_id_new, instance_password)
 
         return jsonify(APIResponse.success(
             data=result


### PR DESCRIPTION
## Refactor and improve instance credential management

### Description
Refactored the instance credential management system to improve security, reliability, and maintainability. The current implementation had several issues related to load record management and credential updating.

### Changes implemented
1. Renamed `update_instance_id` method to [update_instance_credentials](cci:1://file:///Users/baofangyi/github/Second-Me/lpm_kernel/api/domains/loads/load_service.py:141:4-184:65) to better reflect its purpose of updating both instance ID and password.
2. Enhanced error handling to properly validate and report issues during credential updates.
3. Modified the implementation to properly fetch the current load record instead of using a simplistic query that could lead to incorrect record updates.
4. Ensured consistent parameter handling for both instance ID and password.
5. Updated all references to the renamed method across the codebase.

### Technical Details
- Fixed potentially incorrect load record selection in credential update logic by using the proper [get_current_load()](cci:1://file:///Users/baofangyi/github/Second-Me/lpm_kernel/api/domains/loads/load_service.py:17:4-41:64) method
- Improved logging by masking sensitive password information
- Added more descriptive error messages to aid in troubleshooting
- Ensuring data consistency by verifying record existence at multiple steps

### Affected Components
- LoadService (load_service.py)
- Upload API (routes.py)