### PR TITLE
fix: update train parame when retrain

### DIFF
--- a/lpm_kernel/api/domains/trainprocess/routes.py
+++ b/lpm_kernel/api/domains/trainprocess/routes.py
@@ -5,6 +5,7 @@ from charset_normalizer import from_path
 
 from lpm_kernel.api.domains.trainprocess.trainprocess_service import TrainProcessService
 from lpm_kernel.api.domains.trainprocess.training_params_manager import TrainingParamsManager
+from lpm_kernel.api.domains.trainprocess.training_params import TrainingParams
 from ...common.responses import APIResponse
 from threading import Thread
 
@@ -54,21 +55,13 @@ def start_process():
     logger.info("Training process starting...")  # Log the startup
     try:
         data = request.get_json()
-        if not data or "model_name" not in data:
+        training_params = TrainingParams.from_request(data)
+        
+        if not training_params.validate():
             return jsonify(APIResponse.error(message="Missing required parameters"))
 
-        model_name = data["model_name"]
-        
-        # Get optional parameters with default values
-        learning_rate = data.get("learning_rate", None)
-        number_of_epochs = data.get("number_of_epochs", None)
-        concurrency_threads = data.get("concurrency_threads", None)
-        data_synthesis_mode = data.get("data_synthesis_mode", None)
-        use_cuda = data.get("use_cuda", False)  # Default to False if not provided
-        is_cot = data.get("is_cot", None)
-        
         # Log the received parameters
-        logger.info(f"Training parameters: model_name={model_name}, learning_rate={learning_rate}, number_of_epochs={number_of_epochs}, concurrency_threads={concurrency_threads}, data_synthesis_mode={data_synthesis_mode}, is_cot={is_cot}")
+        logger.info(f"Training parameters: {training_params.to_dict()}")
 
         # Create service instance with model name and additional parameters
         last_train_service = TrainProcessService.get_instance()
@@ -80,28 +73,17 @@ def start_process():
                 code=409  # Conflict status code
             ))
             
-
-        train_service = TrainProcessService(current_model_name=model_name)
+        train_service = TrainProcessService(current_model_name=training_params.model_name)
         if not train_service.check_training_condition():
             train_service.reset_progress()
 
         # Save training parameters
-        training_params = {
-            "model_name": model_name,
-            "learning_rate": learning_rate,
-            "number_of_epochs": number_of_epochs,
-            "concurrency_threads": concurrency_threads,
-            "data_synthesis_mode": data_synthesis_mode,
-            "use_cuda": use_cuda,  # Make sure to include use_cuda parameter
-            "is_cot": is_cot
-        }
-        
         params_manager = TrainingParamsManager()
         # Update the latest training parameters
         params_manager.update_training_params(training_params)
         
         # Log training parameters
-        logger.info(f"Saved training parameters: {training_params}")
+        logger.info(f"Saved training parameters: {training_params.to_dict()}")
 
         thread = Thread(target=train_service.start_process)
         thread.daemon = True
@@ -110,15 +92,7 @@ def start_process():
         # Return success response with all parameters
         return jsonify(
             APIResponse.success(
-                data={
-                    "model_name": model_name,
-                    "learning_rate": learning_rate,
-                    "number_of_epochs": number_of_epochs,
-                    "concurrency_threads": concurrency_threads,
-                    "data_synthesis_mode": data_synthesis_mode,
-                    "use_cuda": use_cuda,  # Include in response
-                    "is_cot": is_cot
-                }
+                data=training_params.to_dict()
             )
         )
     
@@ -282,6 +256,12 @@ def retrain():
     
     Request parameters:
         model_name: Model name (required)
+        learning_rate: Learning rate for model training (optional)
+        number_of_epochs: Number of training epochs (optional)
+        concurrency_threads: Number of threads for concurrent processing (optional)
+        data_synthesis_mode: Mode for data synthesis (optional)
+        use_cuda: Whether to use CUDA for training (optional)
+        is_cot: Whether to use chain-of-thought (optional)
     
     Returns:
         Response: JSON response
@@ -297,13 +277,13 @@ def retrain():
     try:
         # get request parameters
         data = request.get_json() or {}
-        model_name = data.get("model_name")
+        training_params = TrainingParams.from_request(data)
         
-        if not model_name:
-            return jsonify(APIResponse.error(message="missing necessary parameter: model_name", code=400))
+        if not training_params.validate():
+            return jsonify(APIResponse.error(message="Missing required parameter: model_name", code=400))
         
         # Create training service instance
-        train_service = TrainProcessService(current_model_name=model_name)
+        train_service = TrainProcessService(current_model_name=training_params.model_name)
         
         # Check if there are any in_progress statuses that need to be reset
         if train_service.progress.progress.data["status"] == "in_progress":
@@ -311,6 +291,10 @@ def retrain():
             logger.info("There is an existing training process that was interrupted.")
             
         train_service.reset_progress()
+        
+        # Save provided training parameters
+        params_manager = TrainingParamsManager()
+        params_manager.update_training_params(training_params, preserve_previous=False)
 
         thread = Thread(target=train_service.start_process)
         thread.daemon = True
@@ -319,9 +303,7 @@ def retrain():
         return jsonify(
             APIResponse.success(
                 message="Successfully reset progress to data processing stage and started training process",
-                data={
-                    "model_name": model_name
-                }
+                data=training_params.to_dict()
             )
         )
     except Exception as e:

--- a/lpm_kernel/api/domains/trainprocess/training_params.py
+++ b/lpm_kernel/api/domains/trainprocess/training_params.py
@@ -1,0 +1,61 @@
+class TrainingParams:
+    """
+    Bean class to encapsulate training parameters used in both start_process and retrain.
+    """
+    def __init__(
+        self,
+        model_name=None,
+        learning_rate=None,
+        number_of_epochs=None,
+        concurrency_threads=None,
+        data_synthesis_mode=None,
+        use_cuda=False,
+        is_cot=False
+    ):
+        self.model_name = model_name
+        self.learning_rate = learning_rate
+        self.number_of_epochs = number_of_epochs
+        self.concurrency_threads = concurrency_threads
+        self.data_synthesis_mode = data_synthesis_mode
+        self.use_cuda = use_cuda
+        self.is_cot = is_cot
+    
+    @classmethod
+    def from_request(cls, request_data):
+        """
+        Create a TrainingParams instance from request data
+        """
+        if not request_data:
+            return cls()
+            
+        return cls(
+            model_name=request_data.get("model_name"),
+            learning_rate=request_data.get("learning_rate"),
+            number_of_epochs=request_data.get("number_of_epochs"),
+            concurrency_threads=request_data.get("concurrency_threads"),
+            data_synthesis_mode=request_data.get("data_synthesis_mode"),
+            use_cuda=request_data.get("use_cuda", False),
+            is_cot=request_data.get("is_cot")
+        )
+    
+    def to_dict(self):
+        """
+        Convert the bean to dictionary
+        """
+        return {
+            "model_name": self.model_name,
+            "learning_rate": self.learning_rate,
+            "number_of_epochs": self.number_of_epochs,
+            "concurrency_threads": self.concurrency_threads,
+            "data_synthesis_mode": self.data_synthesis_mode,
+            "use_cuda": self.use_cuda,
+            "is_cot": self.is_cot
+        }
+    
+    def validate(self):
+        """
+        Validate required parameters
+        """
+        if not self.model_name:
+            return False
+        return True


### PR DESCRIPTION


## Problem Description
Currently, the training parameters are passed around as JSON objects and dictionaries, which leads to:
- Code duplication in parameter retrieval logic
- Lack of type checking and validation
- Excessive JSON parsing and serialization
- Difficulty in maintaining consistent parameter handling across functions

## Solution
Created a TrainingParams bean class to encapsulate training parameters and unified the parameter handling in both [start_process](cci:1://file:///Users/baofangyi/github/Second-Me/lpm_kernel/api/domains/trainprocess/routes.py:16:0-100:86) and [retrain](cci:1://file:///Users/baofangyi/github/Second-Me/lpm_kernel/api/domains/trainprocess/routes.py:10:0-20:61) functions:

1. **Created TrainingParams bean class**:
   - Encapsulates all training parameters in a single class
   - Provides validation method to check required parameters
   - Includes utility methods for conversion between object and dictionary

2. **Enhanced TrainingParamsManager**:
   - Added `preserve_previous` parameter to `update_training_params` method
   - When `preserve_previous=True`, preserves and updates existing parameters
   - When `preserve_previous=False`, discards previous parameters and uses only new ones

3. **Updated API endpoints**:
   - Modified [start_process](cci:1://file:///Users/baofangyi/github/Second-Me/lpm_kernel/api/domains/trainprocess/routes.py:16:0-100:86) function to use the TrainingParams class
   - Modified [retrain](cci:1://file:///Users/baofangyi/github/Second-Me/lpm_kernel/api/domains/trainprocess/routes.py:10:0-20:61) function to use the TrainingParams class with `preserve_previous=False`
   - Simplified parameter handling code

## Benefits
- **Improved code organization**: Parameters are now handled consistently
- **Type safety**: Bean class provides structure and validation
- **Reduced duplication**: Common parameter logic is centralized
- **Better maintainability**: Adding new parameters requires changes in fewer places
- **Clearer functionality**: [retrain](cci:1://file:///Users/baofangyi/github/Second-Me/lpm_kernel/api/domains/trainprocess/routes.py:10:0-20:61) now explicitly discards previous parameters

## Implementation Details
The changes were made to:
- `/lpm_kernel/api/domains/trainprocess/training_params.py` (new file)
- `/lpm_kernel/api/domains/trainprocess/training_params_manager.py`
- [/lpm_kernel/api/domains/trainprocess/routes.py](cci:7://file:///Users/baofangyi/github/Second-Me/lpm_kernel/api/domains/trainprocess/routes.py:0:0-0:0)