### PR TITLE
preserve training param

### DIFF
--- a/lpm_kernel/api/domains/trainprocess/training_params_manager.py
+++ b/lpm_kernel/api/domains/trainprocess/training_params_manager.py
@@ -45,15 +45,16 @@ class TrainingParamsManager:
         return cls._params_file_path
     
     @classmethod
-    def update_training_params(cls, params):
+    def update_training_params(cls, params, use_previous_params=True):
         """
         Update the latest training parameters and save to file
         
         Args:
             params: Dictionary containing training parameters
+            use_previous_params: Whether to use previous training parameters as base
         """
         # First try to load existing parameters
-        current_params = cls.get_latest_training_params()
+        current_params = cls.get_latest_training_params() if use_previous_params else cls._default_training_params.copy()
         
         # Update parameters
         for key, value in params.items():


### PR DESCRIPTION
# Enhancement: Update retrain method to handle training parameters like start_process

## Description
Currently, the retrain method lacks the ability to update training parameters in the same way as the start_process method. This enhancement adds parameter handling capabilities to the retrain method and modifies the `TrainingParamsManager.update_training_params` method to support resetting parameters when retraining.

## Changes Made
- Enhanced the retrain endpoint to accept the same training parameters as start_process:
  - learning_rate
  - number_of_epochs
  - concurrency_threads
  - data_synthesis_mode
  - use_cuda
  - is_cot
- Modified the `TrainingParamsManager.update_training_params` method to accept a `use_previous_params` flag
- Set `use_previous_params=False` in the retrain method to ensure parameters are reset when retraining
- Updated endpoint documentation to reflect new parameters
- Added proper response data including all training parameters

## Technical Details
- The retrain method now processes all training parameters from the request JSON
- Default values are applied for missing parameters
- When calling update_training_params, we pass `use_previous_params=False` to reset parameters
- The API response now includes all training parameters in the data section

## Testing
1. Call the `/api/trainprocess/retrain` endpoint with a JSON payload containing:
   ```json
   {
     "model_name": "Qwen2.5-0.5B-Instruct",
     "learning_rate": 2e-4,
     "number_of_epochs": 5,
     "concurrency_threads": 4,
     "data_synthesis_mode": "medium",
     "use_cuda": true,
     "is_cot": true
   }