### PR TITLE
fix: failed check graphrag version target when two "Version:" found

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -200,7 +200,7 @@ install_graphrag() {
     
     # Check the current graphrag version in Poetry environment
     log_step "Checking graphrag version in Poetry environment"
-    GRAPHRAG_VERSION=$(poetry run pip show graphrag 2>/dev/null | grep "Version:" | cut -d " " -f2)
+    GRAPHRAG_VERSION=$(poetry run pip show graphrag 2>/dev/null | awk '/^Versi  on: / {print $2; exit}')
     GRAPHRAG_TARGET="1.2.1.dev27"
     GRAPHRAG_LOCAL_PATH="dependencies/graphrag-${GRAPHRAG_TARGET}.tar.gz"
 


### PR DESCRIPTION
graphrag is re-installed every time due to that setup.sh fails to find installed graphrag target version when two "Versions:" is found in the environment:
```
Version: 1.2.1.dev27
Metadata-Version: 2.3
```
when the output of `poetry run pip show graphrag 2>/dev/nul` is
```
Name: graphrag
Version: 1.2.1.dev27
Summary: GraphRAG: A graph-based retrieval-augmented generation (RAG) system.
Home-page:
Author: Alonso Guevara Fernández
Author-email: alonsog@microsoft.com
License: MIT
Location: /workspace/myapp/.venv/lib/python3.12/site-packages
Requires: aiofiles, azure-cosmos, azure-identity, azure-search-documents, azure-storage-blob, devtools, en-core-web-md, environs, fnllm, future, graspologic, httpx, json-repair, lancedb, networkx, nltk, numpy, openai, pandas, pyarrow, pydantic, python-dotenv, pyyaml, rich, spacy, tenacity, textblob, tiktoken, tqdm, typer, typing-extensions, umap-learn
Required-by:
Metadata-Version: 2.3
Installer: pip
Classifiers:
  License :: OSI Approved :: MIT License
  Programming Language :: Python :: 3
  Programming Language :: Python :: 3.10
  Programming Language :: Python :: 3.11
  Programming Language :: Python :: 3.12
Entry-points:
  [console_scripts]
  graphrag=graphrag.cli.main:app

Project-URLs:
  Source, https://github.com/microsoft/graphrag
```