### PR TITLE
fix: handle both reasoning_content and reasoning attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
   
-[![Homepage](https://img.shields.io/badge/Second_Me-Homepage-blue?style=flat-square&logo=homebridge)](https://www.secondme.io/)
+[![Homepage](https://img.shields.io/badge/Second_Me-Homepage-blue?style=flat-square&logo=homebridge)](https://home.second.me/)
 [![AI-native Memory](https://img.shields.io/badge/AI--native_Memory-arXiv-orange?style=flat-square&logo=academia)](https://arxiv.org/abs/2406.18312)
 [![AI-native Memory 2.0](https://img.shields.io/badge/AI--native_Memory_2.0-arXiv-red?style=flat-square&logo=arxiv)](https://arxiv.org/abs/2503.08102)
 [![Discord](https://img.shields.io/badge/Chat-Discord-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/GpWHQNUwrg)

--- a/lpm_kernel/L2/data_pipeline/data_prep/diversity/diversity_data_generator.py
+++ b/lpm_kernel/L2/data_pipeline/data_prep/diversity/diversity_data_generator.py
@@ -498,12 +498,13 @@ class DiversityDataGenerator:
             )
             if self.is_cot:
                 response_message = response.choices[0].message
-                res = "<think>" + response_message.reasoning_content + "</think>" + response_message.content
+                reasoning = getattr(response_message, 'reasoning_content', None) or getattr(response_message, 'reasoning', None) or ''
+                res = "<think>" + reasoning + "</think>" + response_message.content
             else:
                 res = response.choices[0].message.content
         except Exception as e:
             logging.error(traceback.format_exc())
-        
+
         # post-processing
         try:
             pattern = r"Question\s*\d+\s*:\s*(.*?)\|\|"
@@ -549,10 +550,11 @@ class DiversityDataGenerator:
             )
             if self.is_cot:
                 response_message = response.choices[0].message
-                res = "<think>" + response_message.reasoning_content + "</think>" + response_message.content
+                reasoning = getattr(response_message, 'reasoning_content', None) or getattr(response_message, 'reasoning', None) or ''
+                res = "<think>" + reasoning + "</think>" + response_message.content
             else:
                 res = response.choices[0].message.content
         except Exception as e:
             logging.error(traceback.format_exc())
-            
+
         return res, answer_type

--- a/lpm_kernel/L2/data_pipeline/data_prep/preference/preference_QA_generate.py
+++ b/lpm_kernel/L2/data_pipeline/data_prep/preference/preference_QA_generate.py
@@ -132,7 +132,8 @@ class PreferenceQAGenerator:
                 )
                 response_message = res.choices[0].message
                 if self.is_cot:
-                    return "<think>" + response_message.reasoning_content + "</think>" + response_message.content
+                    reasoning = getattr(response_message, 'reasoning_content', None) or getattr(response_message, 'reasoning', None) or ''
+                    return "<think>" + reasoning + "</think>" + response_message.content
                 else:
                     return response_message.content
             except Exception as e:

--- a/lpm_kernel/L2/data_pipeline/data_prep/selfqa/selfqa_generator.py
+++ b/lpm_kernel/L2/data_pipeline/data_prep/selfqa/selfqa_generator.py
@@ -229,10 +229,10 @@ class SelfQA:
 
     def get_remote_response(self, messages: list) -> str:
         """Get response from OpenAI / DeepSeek API.
-        
+
         Args:
             messages: The messages to send to the OpenAI / DeepSeek API.
-            
+
         Returns:
             The response content from OpenAI / DeepSeek, or None if an error occurs.
         """
@@ -243,7 +243,8 @@ class SelfQA:
             )
             response_message = res.choices[0].message
             if self.is_cot:
-                return "<think>" + response_message.reasoning_content + "</think>" + response_message.content
+                reasoning = getattr(response_message, 'reasoning_content', None) or getattr(response_message, 'reasoning', None) or ''
+                return "<think>" + reasoning + "</think>" + response_message.content
             else:
                 return response_message.content
         except Exception as e:


### PR DESCRIPTION
## Summary
Fix `AttributeError: 'ChatCompletionMessage' object has no attribute 'reasoning_content'` when using DeepSeek R1 API.

## Changes
- Use `getattr()` with fallback to handle both `reasoning_content` and `reasoning` attribute names
- Applied to 3 files: `selfqa_generator.py`, `preference_QA_generate.py`, `diversity_data_generator.py`

## Related Issues
Fixes #370, #327

Signed-off-by: majiayu000 <1835304752@qq.com>